### PR TITLE
KEP-277: RAFT persistence implementation

### DIFF
--- a/raft/CMakeLists.txt
+++ b/raft/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_library(raft
+        log_entry.hpp
         raft_base.hpp
         raft.cpp
-        raft.hpp)
+        raft.hpp
+        )
 
 target_link_libraries(raft)
 target_include_directories(raft PRIVATE ${JSONCPP_INCLUDE_DIRS})

--- a/raft/log_entry.hpp
+++ b/raft/log_entry.hpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <ostream>
+#include <boost/beast/core/detail/base64.hpp>
+#include <string>
+
+
+namespace bzn
+{
+    const std::string MSG_ERROR_ENCOUNTERED_INVALID_ENTRY_IN_LOG{"ENCOUNTERED_INVALID_ENTRY_IN_LOG"};
+
+
+    struct log_entry
+    {
+        friend std::ostream &operator<<(std::ostream& out, const log_entry& obj)
+        {
+            out << obj.log_index << " " << obj.term << " " << boost::beast::detail::base64_encode(obj.json_to_string(obj.msg)) << "\n";
+            return out;
+        }
+
+
+        friend std::istream &operator>>(std::istream& in, log_entry& obj)
+        {
+            std::string msg_string;
+            obj.log_index = std::numeric_limits<uint32_t>::max();;
+            obj.term = std::numeric_limits<uint32_t>::max();;
+            obj.msg.clear();
+            in >> obj.log_index >> obj.term >> msg_string;
+            if (!msg_string.empty())
+            {
+                Json::Reader reader;
+                if (!reader.parse(boost::beast::detail::base64_decode(msg_string), obj.msg))
+                {
+                    throw std::runtime_error(bzn::MSG_ERROR_ENCOUNTERED_INVALID_ENTRY_IN_LOG + ":" + reader.getFormattedErrorMessages());
+                }
+            }
+            return in;
+        }
+
+
+        inline std::string
+        json_to_string(const bzn::message& msg) const
+        {
+            Json::FastWriter fastWriter;
+            return fastWriter.write(msg);
+        }
+
+        uint32_t log_index;
+        uint32_t term;
+        bzn::message msg;
+    };
+}
+

--- a/raft/log_entry.hpp
+++ b/raft/log_entry.hpp
@@ -36,8 +36,8 @@ namespace bzn
         friend std::istream &operator>>(std::istream& in, log_entry& obj)
         {
             std::string msg_string;
-            obj.log_index = std::numeric_limits<uint32_t>::max();;
-            obj.term = std::numeric_limits<uint32_t>::max();;
+            obj.log_index = std::numeric_limits<uint32_t>::max();
+            obj.term = std::numeric_limits<uint32_t>::max();
             obj.msg.clear();
             in >> obj.log_index >> obj.term >> msg_string;
             if (!msg_string.empty())

--- a/raft/test/CMakeLists.txt
+++ b/raft/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(test_srcs raft_test.cpp)
-set(test_libs raft bootstrap)
+set(test_libs raft storage bootstrap)
 
 add_gmock_test(raft_tests)


### PR DESCRIPTION
Implements RAFT log state and log persistence. As a daemon commits entries, each entry is appended to a log file on local storage, at the same time the RAFT state variables are also persisted to a separate log file.

If the daemon is stopped and later restarted, the log entries are used to rehydrate the daemon to the point at which it was shut down.

In addition, the daemon storage is reloaded from the loaded log entries.