### PR TITLE
KEP-366 - Added log entry type enum to the log_entry structure to all…

### DIFF
--- a/raft/log_entry.hpp
+++ b/raft/log_entry.hpp
@@ -23,6 +23,13 @@ namespace bzn
 {
     const std::string MSG_ERROR_ENCOUNTERED_INVALID_ENTRY_IN_LOG{"ENCOUNTERED_INVALID_ENTRY_IN_LOG"};
 
+    enum class log_entry_type : uint8_t
+    {
+        log_entry,
+        single_quorum,
+        joint_quorum
+    };
+
 
     struct log_entry
     {
@@ -59,9 +66,10 @@ namespace bzn
             return fastWriter.write(msg);
         }
 
-        uint32_t log_index;
-        uint32_t term;
-        bzn::message msg;
+        log_entry_type  entry_type;
+        uint32_t        log_index;
+        uint32_t        term;
+        bzn::message    msg;
     };
 }
 

--- a/raft/raft.cpp
+++ b/raft/raft.cpp
@@ -310,7 +310,7 @@ raft::handle_ws_append_entries(const bzn::message& msg, std::shared_ptr<bzn::ses
         if (!msg["data"]["entries"].empty() && leader_prev_index == 0)
         {
             this->log_entries.emplace_back(
-                log_entry{++this->last_log_index, entry_term, msg["data"]["entries"]});
+                log_entry{bzn::log_entry_type::log_entry, ++this->last_log_index, entry_term, msg["data"]["entries"]});
         }
     }
     else
@@ -323,7 +323,7 @@ raft::handle_ws_append_entries(const bzn::message& msg, std::shared_ptr<bzn::ses
             if (!msg["data"]["entries"].empty())
             {
                 this->log_entries.emplace_back(
-                    log_entry{++this->last_log_index, entry_term, msg["data"]["entries"]});
+                    log_entry{bzn::log_entry_type::log_entry, ++this->last_log_index, entry_term, msg["data"]["entries"]});
             }
         }
         else
@@ -593,7 +593,7 @@ raft::append_log(const bzn::message& msg)
         return false;
     }
 
-    this->log_entries.emplace_back(log_entry{++this->last_log_index, this->current_term, msg});
+    this->log_entries.emplace_back(log_entry{bzn::log_entry_type::log_entry, ++this->last_log_index, this->current_term, msg});
 
     return true;
 }


### PR DESCRIPTION
This was implemented by adding a new log_entry_type enum member to the log_entry struct.
This allows us to differentiate between a log_entry, single_quorum and joint_quorum entry types. Allowing the log to contain the peers lists as they are updated.
The new member was required to allow us to search the log entries for the latest quorum entry without having to parse the bzn::message member.