### PR TITLE
KEP-366 - Added functionality to find the last quorum type log_entry …

### DIFF
--- a/raft/raft.hpp
+++ b/raft/raft.hpp
@@ -62,6 +62,8 @@ namespace bzn
         FRIEND_TEST(raft, test_that_leader_sends_entries_and_commits_when_enough_peers_have_saved_them);
         FRIEND_TEST(raft, test_that_start_randomly_schedules_callback_for_starting_an_election_and_wins);
         FRIEND_TEST(raft, test_that_raft_bails_on_bad_rehydrate);
+        FRIEND_TEST(raft, test_raft_can_find_last_quorum_log_entry);
+        FRIEND_TEST(raft, test_raft_throws_exception_when_no_quorum_can_be_found_in_log);
 
         void start_heartbeat_timer();
         void handle_heartbeat_timeout(const boost::system::error_code& ec);
@@ -92,6 +94,8 @@ namespace bzn
         void load_state();
 
         void perform_commit(uint32_t& commit_index, const bzn::log_entry& log_entry);
+
+        bzn::log_entry last_quorum();
 
         // raft state...
         bzn::raft_state current_state = raft_state::follower;


### PR DESCRIPTION
The log entries are stored in a std::vector<bzn::log_entry> container. So to find the last quorum entry I wrote a method called

bzn::log_entry last_quorum()

which stupidly reverse iterates from the last log entry, log_entries.end(), to the first log entry, log_entries.begin(), looking for a log_entry that is not a bzn::log_entry_type::log_entry. This may become a problem when we have more log entry types, some of which are not involved in the quorum. So I wrote unit tests that will fail if that happens.

In later tasks I will refactor this method to make use of a state member in RAFT that will keep track of the last entered quorum log_entry, but that functionality has not been implemented yet.