### PR TITLE
KEP-349 - LOGs no longer show entire append entry messages

### DIFF
--- a/crud/crud.cpp
+++ b/crud/crud.cpp
@@ -226,7 +226,7 @@ crud::handle_ws_crud_messages(const bzn::message& ws_msg, std::shared_ptr<bzn::s
 
     if (!ws_msg.isMember("msg"))
     {
-        LOG(error) << "Invalid message: " << ws_msg.toStyledString();
+        LOG(error) << "Invalid message: " << ws_msg.toStyledString().substr(0,60) << "...";
         response.mutable_resp()->set_error(bzn::MSG_INVALID_CRUD_COMMAND);
         session->send_message(std::make_shared<std::string>(response.SerializeAsString()), true);
         return;
@@ -234,7 +234,7 @@ crud::handle_ws_crud_messages(const bzn::message& ws_msg, std::shared_ptr<bzn::s
 
     if (!msg.ParseFromString(boost::beast::detail::base64_decode(ws_msg["msg"].asString())))
     {
-        LOG(error) << "Failed to decode message: " << ws_msg.toStyledString();
+        LOG(error) << "Failed to decode message: " << ws_msg.toStyledString().substr(0,60) << "...";
         response.mutable_resp()->set_error(bzn::MSG_INVALID_CRUD_COMMAND);
         session->send_message(std::make_shared<std::string>(response.SerializeAsString()), true);
         return;

--- a/node/node.cpp
+++ b/node/node.cpp
@@ -109,7 +109,7 @@ node::priv_msg_handler(const Json::Value& msg, std::shared_ptr<bzn::session_base
         }
     }
 
-    LOG(debug) << "no handler for:\n" << msg.toStyledString();
+    LOG(debug) << "no handler for:\n" << msg.toStyledString().substr(0, 60) << "...";
 
     session->close();
 }

--- a/node/test/node_test.cpp
+++ b/node/test/node_test.cpp
@@ -217,7 +217,7 @@ namespace  bzn
         node->register_for_message("crud",
             [](const bzn::message& msg, std::shared_ptr<bzn::session_base> session)
             {
-                LOG(info) << '\n' << msg.toStyledString();
+                LOG(info) << '\n' << msg.toStyledString().substr(0, 60) << "...";
 
                 // echo back what the client sent...
                 session->send_message(std::make_shared<bzn::message>(msg), true);

--- a/raft/raft.cpp
+++ b/raft/raft.cpp
@@ -202,7 +202,7 @@ raft::request_vote_request()
 void
 raft::handle_request_vote_response(const bzn::message& msg, std::shared_ptr<bzn::session_base> /*session*/)
 {
-    LOG(debug) << '\n' << msg.toStyledString();
+    LOG(debug) << '\n' << msg.toStyledString().substr(0, 60) << "...";
 
     // If I'm the leader and my term is less than vote request then I should step down and become a follower.
     if (this->current_state == bzn::raft_state::leader)
@@ -346,7 +346,7 @@ raft::handle_ws_append_entries(const bzn::message& msg, std::shared_ptr<bzn::ses
 
     auto resp_msg = std::make_shared<bzn::message>(bzn::create_append_entries_response(this->uuid, this->current_term, success, this->last_log_index));
 
-    LOG(debug) << "Sending WS message:\n" << resp_msg->toStyledString();
+    LOG(debug) << "Sending WS message:\n" << resp_msg->toStyledString().substr(0, 60) << "...";
 
     session->send_message(resp_msg, true);
 
@@ -374,7 +374,7 @@ raft::handle_ws_raft_messages(const bzn::message& msg, std::shared_ptr<bzn::sess
 {
     std::lock_guard<std::mutex> lock(this->raft_lock);
 
-    LOG(debug) << "Received WS message:\n" << msg.toStyledString();
+    LOG(debug) << "Received WS message:\n" << msg.toStyledString().substr(0, 60) << "...";
 
     uint32_t term = msg["data"]["term"].asUInt();
 
@@ -383,7 +383,6 @@ raft::handle_ws_raft_messages(const bzn::message& msg, std::shared_ptr<bzn::sess
         // bleh!
         if (msg["cmd"].asString() == "RequestVote")
         {
-            std::cout << "RequestVote:" << msg.toStyledString() << std::endl;
             this->handle_ws_request_vote(msg, session);
         }
         else if (msg["cmd"].asString() == "AppendEntries")
@@ -425,7 +424,7 @@ raft::handle_ws_raft_messages(const bzn::message& msg, std::shared_ptr<bzn::sess
 
                 auto resp_msg = std::make_shared<bzn::message>(bzn::create_append_entries_response(this->uuid, this->current_term, true, this->last_log_index));
 
-                LOG(debug) << "Sending WS message:\n" << resp_msg->toStyledString();
+                LOG(debug) << "Sending WS message:\n" << resp_msg->toStyledString().substr(0, 60) << "...";
 
                 session->send_message(resp_msg, true);
             }
@@ -526,7 +525,7 @@ raft::request_append_entries()
 
             auto req = std::make_shared<bzn::message>(bzn::create_append_entries_request(this->uuid, this->current_term, this->commit_index, prev_index, prev_term, entry_term, msg));
 
-            LOG(debug) << "Sending request:\n" << req->toStyledString();
+            LOG(debug) << "Sending request:\n" << req->toStyledString().substr(0, 60) << "...";
 
             this->node->send_message(ep, req);
         }
@@ -554,7 +553,7 @@ raft::handle_request_append_entries_response(const bzn::message& msg, std::share
     if (msg["data"]["matchIndex"].asUInt() > this->log_entries.size() ||
         msg["data"]["term"].asUInt() != this->current_term)
     {
-        LOG(error) << "received bad match index or term: \n" << msg.toStyledString();
+        LOG(error) << "received bad match index or term: \n" << msg.toStyledString().substr(0, 60) << "...";
         return;
     }
 

--- a/raft/test/raft_test.cpp
+++ b/raft/test/raft_test.cpp
@@ -363,7 +363,7 @@ namespace bzn
         raft->register_commit_handler(
             [&](const bzn::message& msg)
             {
-                LOG(info) << "commit:\n" << msg.toStyledString();
+                LOG(info) << "commit:\n" << msg.toStyledString().substr(0, 60) << "...";
 
                 commit_handler_called = true;
                 ++commit_handler_times_called;
@@ -466,7 +466,7 @@ namespace bzn
         raft->register_commit_handler(
             [&](const bzn::message& msg)
             {
-                LOG(info) << "commit:\n" << msg.toStyledString();
+                LOG(info) << "commit:\n" << msg.toStyledString().substr(0, 60) << "...";
                 ++commit_handler_times_called;
                 return true;
             });

--- a/swarm/main.cpp
+++ b/swarm/main.cpp
@@ -201,7 +201,7 @@ main(int argc, const char* argv[])
         node->register_for_message("ping",
             [](const bzn::message& msg, std::shared_ptr<bzn::session_base> session)
             {
-                LOG(debug) << '\n' << msg.toStyledString();
+                LOG(debug) << '\n' << msg.toStyledString().substr(0, 60) << "...";
 
                 auto reply = std::make_shared<bzn::message>(msg);
                 (*reply)["bzn-api"] = "pong";


### PR DESCRIPTION
To find the offending log messages, that potentially show key/value contents I did a regex search with
     'LOG\s*+('
which gave me the locations of all of the LOG instances and also
     'cout'
which did have a few hits... I removed the one with a "msg" in it.

Instead of completely removing the large LOG messages, they were all of the
     LOG(debug) << "Sending WS message:\n" << resp_msg->toStyledString();
variety, I append a substring
     LOG(debug) << "Sending WS message:\n" << resp_msg->toStyledString().substr(0, 60) << "...";
and ellipses to indicate the truncation.

If this is not satisfactory, I can just remove them.