### PR TITLE
KEP-112 : KEP-450 and KEP-452 Setting and Display Storage Limits

### DIFF
--- a/options/options.cpp
+++ b/options/options.cpp
@@ -14,12 +14,17 @@
 
 #include <options/options.hpp>
 #include <boost/program_options.hpp>
+#include <boost/lexical_cast.hpp>
+#include <regex>
 #include <iostream>
 #include <fstream>
 #include <swarm_version.hpp>
 
 namespace po = boost::program_options;
 using namespace bzn;
+
+
+const std::map<char, size_t> options_base::BYTE_SUFFIXES = std::map<char, size_t>({{'B', 1}, {'K', 1024}, {'M', 1048576}, {'G', 1073741824}, {'T', 1099511627776}});
 
 
 namespace
@@ -39,12 +44,17 @@ namespace
     const std::string NODE_UUID                  = "uuid";
     const std::string AUDIT_MEM_SIZE_KEY         = "audit_mem_size";
     const std::string STATE_DIR_KEY              = "state_dir";
+    const std::string MAX_STORAGE_KEY            = "max_storage";
 
     // this is 10k error strings in a vector, which is pessimistically 10MB, which is small enough that no one should mind
     const size_t DEFAULT_AUDIT_MEM_SIZE          = 10000;
 
     const std::string DEFAULT_STATE_DIR          = "./.state/";
 
+    // The default maximum allowed storage for a node is 2G
+    const size_t DEFAULT_MAX_STORAGE_SIZE        = 2147483648;
+    
+    
     // https://stackoverflow.com/questions/8899069
     bool is_hex_notation(std::string const& s)
     {
@@ -73,7 +83,6 @@ options::parse_command_line(int argc, const char* argv[])
     {
         return this->validate();
     }
-
     return false;
 }
 
@@ -349,4 +358,30 @@ options::parse(int argc, const char* argv[])
     }
 
     return true;
+}
+
+
+size_t
+options::get_max_storage() const
+{
+    size_t value = DEFAULT_MAX_STORAGE_SIZE;
+
+    if(this->config_data.isMember(MAX_STORAGE_KEY))
+    {
+        const std::string max_storage{this->config_data[MAX_STORAGE_KEY].asString()};
+        const std::regex expr{"(\\d+)([K,M,G,T]?[B]?)"};
+        std::smatch base_match;
+
+        if(std::regex_match(max_storage, base_match, expr))
+        {
+            std::string suffix = base_match[2];
+            value = boost::lexical_cast<size_t>(base_match[1])
+                    * this->BYTE_SUFFIXES.at(suffix.empty() ? 'B' : suffix[0]);
+        }
+        else
+        {
+            throw std::runtime_error(std::string("\nUnable to parse max storage value from options: " + max_storage));
+        }
+    }
+    return value;
 }

--- a/options/options.hpp
+++ b/options/options.hpp
@@ -49,6 +49,8 @@ namespace bzn
 
         std::string get_state_dir() const override;
 
+        size_t get_max_storage() const override;
+
     private:
         bool parse(int argc, const char* argv[]);
 

--- a/options/options_base.hpp
+++ b/options/options_base.hpp
@@ -20,12 +20,16 @@
 #include <include/optional.hpp>
 #include <include/boost_asio_beast.hpp>
 #include <string>
+#include <map>
 
 namespace bzn
 {
+
     class options_base
     {
     public:
+        // Suffixes for the max size parser.
+        static const std::map<char, size_t> BYTE_SUFFIXES;//{{'B', 1}, {'K', 1024}, {'M', 1048576}, {'G', 1073741824}, {'T', 1099511627776}};
 
         virtual ~options_base() = default;
 
@@ -99,10 +103,17 @@ namespace bzn
 
 
          /**
-          * Get the director for storing swarm state data
+          * Get the directory for storing swarm state data
           * @return directory
           */
          virtual std::string get_state_dir() const = 0;
+
+
+         /**
+          * Get the maximum allowed storage for the daemon.
+          * @return
+          */
+         virtual size_t get_max_storage() const = 0;
 
     };
 

--- a/swarm/main.cpp
+++ b/swarm/main.cpp
@@ -125,6 +125,18 @@ get_http_listener_port(const bzn::options& options, const bzn::bootstrap_peers& 
 }
 
 
+size_t
+get_state_file_size(const bzn::options& options)
+{
+    boost::filesystem::path state_file_path{options.get_state_dir() + "/" + options.get_uuid() + ".dat"};
+    if(boost::filesystem::exists(state_file_path))
+    {
+        return size_t(boost::filesystem::file_size(state_file_path));
+    }
+    return 0;
+}
+
+
 void
 print_banner(const bzn::options& options, double eth_balance)
 {
@@ -135,7 +147,9 @@ print_banner(const bzn::options& options, double eth_balance)
        << "   Ethereum Address ID: " << options.get_ethererum_address()  << "\n"
        << "      Local IP Address: " << options.get_listener().address().to_string() << "\n"
        << "               On port: " << options.get_listener().port()    << "\n"
-       << "         Token Balance: " << eth_balance << " ETH\n"
+       << "         Token Balance: " << eth_balance << " ETH" << "\n"
+       << "     Maximimum Storage: " << options.get_max_storage() << " Bytes" << "\n"
+       << "          Used Storage: " << get_state_file_size(options) << " Bytes" << "\n"
        << '\n';
 
     std::cout << ss.str();


### PR DESCRIPTION
The functionality to allow us to set the maximum storage setting in the config file, and display the maximum storage value and current storage size (the size in bytes of the .dat file).