### PR TITLE
KEP-112: If RAFT exceeds the max storage set in the options file, it …

### DIFF
--- a/options/options_base.hpp
+++ b/options/options_base.hpp
@@ -29,7 +29,7 @@ namespace bzn
     {
     public:
         // Suffixes for the max size parser.
-        static const std::map<char, size_t> BYTE_SUFFIXES;//{{'B', 1}, {'K', 1024}, {'M', 1048576}, {'G', 1073741824}, {'T', 1099511627776}};
+        static const std::map<char, size_t> BYTE_SUFFIXES;
 
         virtual ~options_base() = default;
 

--- a/raft/raft.cpp
+++ b/raft/raft.cpp
@@ -44,7 +44,7 @@ raft::raft(
         , const bzn::peers_list_t& peers
         , bzn::uuid_t uuid
         , const std::string state_dir
-        , const size_t maximum_raft_storage)
+        , size_t maximum_raft_storage)
     : timer(io_context->make_unique_steady_timer())
     , uuid(std::move(uuid))
     , node(std::move(node))

--- a/raft/raft.cpp
+++ b/raft/raft.cpp
@@ -27,6 +27,7 @@ namespace
     const std::string MSG_ERROR_EMPTY_LOG_ENTRY_FILE{"Empty log entry file. Please delete .state folder."};
     const std::string MSG_ERROR_INVALID_STATE_FILE{"Invalid state file. Please delete the .state folder."};
     const std::string MSG_NO_PEERS_IN_LOG{"Unable to find peers in log entries."};
+
     const std::chrono::milliseconds DEFAULT_HEARTBEAT_TIMER_LEN{std::chrono::milliseconds(250)};
     const std::chrono::milliseconds  DEFAULT_ELECTION_TIMER_LEN{std::chrono::milliseconds(1250)};
 
@@ -42,7 +43,8 @@ raft::raft(
         , std::shared_ptr<bzn::node_base> node
         , const bzn::peers_list_t& peers
         , bzn::uuid_t uuid
-        , const std::string state_dir)
+        , const std::string state_dir
+        , const size_t maximum_raft_storage)
     : timer(io_context->make_unique_steady_timer())
     , uuid(std::move(uuid))
     , node(std::move(node))
@@ -60,7 +62,14 @@ raft::raft(
     this->state_files_exist() ? this->load_state()
                                : this->create_state_files(log_path, peers);
 
-    this->raft_log = std::make_shared<bzn::raft_log>(log_path);
+    this->raft_log = std::make_shared<bzn::raft_log>(log_path, maximum_raft_storage);
+
+    // KEP-112 Bail if the raft storage exceeds the max storage
+    if(this->raft_log->maximum_storage_exceeded())
+    {
+        LOG(error) << MSG_ERROR_MAXIMUM_STORAGE_EXCEEDED;
+        throw std::runtime_error(MSG_ERROR_MAXIMUM_STORAGE_EXCEEDED);
+    }
 }
 
 
@@ -407,7 +416,85 @@ raft::create_joint_quorum_by_removing_peer(const bzn::message& last_quorum_messa
 }
 
 
+void
+raft::handle_add_peer(std::shared_ptr<bzn::session_base> session, const bzn::message &peer)
+{
+    if (this->get_state() != bzn::raft_state::leader)
+    {
+        bzn::message response;
+        response["error"] = ERROR_ADD_PEER_MUST_BE_SENT_TO_LEADER;
+        session->send_message(std::make_shared<bzn::message>(response), true);
+        return;
+    }
 
+    bzn::log_entry last_quorum_entry = this->raft_log->last_quorum_entry();
+    if (last_quorum_entry.entry_type == bzn::log_entry_type::joint_quorum)
+    {
+        bzn::message response;
+        response["error"] = MSG_ERROR_CURRENT_QUORUM_IS_JOINT;
+        session->send_message(std::make_shared<bzn::message>(response), true);
+        return;
+    }
+
+    const auto &same_peer = std::find_if(last_quorum_entry.msg["msg"]["peers"].begin(),
+                                         last_quorum_entry.msg["msg"]["peers"].end(),
+                                         [&](const auto &p)
+                                         {
+                                             return p["uuid"].asString() == peer["uuid"].asString();
+                                         });
+    if (same_peer != last_quorum_entry.msg["msg"]["peers"].end())
+    {
+        bzn::message response;
+        response["error"] = ERROR_PEER_ALREADY_EXISTS;
+        session->send_message(std::make_shared<bzn::message>(response), true);
+        return;
+    }
+
+    this->peer_match_index[peer["uuid"].asString()] = 1;
+    this->append_log_unsafe(this->create_joint_quorum_by_adding_peer(last_quorum_entry.msg, peer),
+                            bzn::log_entry_type::joint_quorum);
+    return;
+}
+
+
+void
+raft::handle_remove_peer(std::shared_ptr<bzn::session_base> session, const std::string& uuid)
+{
+    if (this->get_state() != bzn::raft_state::leader)
+    {
+        bzn::message response;
+        response["error"] = ERROR_REMOVE_PEER_MUST_BE_SENT_TO_LEADER;
+        session->send_message(std::make_shared<bzn::message>(response), true);
+        return;
+    }
+
+    bzn::log_entry last_quorum_entry = this->raft_log->last_quorum_entry();
+    if (last_quorum_entry.entry_type == bzn::log_entry_type::joint_quorum)
+    {
+        bzn::message response;
+        response["error"] = MSG_ERROR_CURRENT_QUORUM_IS_JOINT;
+        session->send_message(std::make_shared<bzn::message>(response), true);
+        return;
+    }
+
+    const auto &peers = last_quorum_entry.msg["msg"]["peers"];
+    const auto &same_peer = std::find_if(
+            peers.begin(), peers.end(), [&](const auto &p)
+            {
+                return p["uuid"].asString() == uuid;
+            });
+    if (same_peer == peers.end())
+    {
+        bzn::message response;
+        response["error"] = ERROR_PEER_NOT_FOUND;
+        session->send_message(std::make_shared<bzn::message>(response), true);
+        return;
+    }
+
+    this->append_log_unsafe(this->create_joint_quorum_by_removing_peer(last_quorum_entry.msg, uuid),
+                            bzn::log_entry_type::joint_quorum);
+    return;
+}
 
 
 void
@@ -419,76 +506,12 @@ raft::handle_ws_raft_messages(const bzn::message& msg, std::shared_ptr<bzn::sess
     // TODO: refactor add/remove peers to move the functionality into handlers
     if(msg["cmd"].asString()=="add_peer")
     {
-        if(this->get_state() != bzn::raft_state::leader)
-        {
-            bzn::message response;
-            response["error"] = ERROR_ADD_PEER_MUST_BE_SENT_TO_LEADER;
-            session->send_message(std::make_shared<bzn::message>(response), true);
-            return;
-        }
-
-        bzn::log_entry last_quorum_entry = this->raft_log->last_quorum_entry();
-        if(last_quorum_entry.entry_type == bzn::log_entry_type::joint_quorum)
-        {
-            bzn::message response;
-            response["error"] = MSG_ERROR_CURRENT_QUORUM_IS_JOINT;
-            session->send_message(std::make_shared<bzn::message>(response), true);
-            return;
-        }
-
-        const auto& same_peer = std::find_if(last_quorum_entry.msg["msg"]["peers"].begin(), last_quorum_entry.msg["msg"]["peers"].end(),
-                [&](const auto& p)
-                {
-                    return p["uuid"].asString() == msg["data"]["peer"]["uuid"].asString();
-                });
-        if(same_peer != last_quorum_entry.msg["msg"]["peers"].end())
-        {
-            bzn::message response;
-            response["error"] = ERROR_PEER_ALREADY_EXISTS;
-            session->send_message(std::make_shared<bzn::message>(response), true);
-            return;
-        }
-
-        this->peer_match_index[msg["data"]["peer"]["uuid"].asString()] = 1;
-        this->append_log_unsafe(this->create_joint_quorum_by_adding_peer(last_quorum_entry.msg, msg["data"]["peer"]), bzn::log_entry_type::joint_quorum);
+        this->handle_add_peer(session, msg["data"]["peer"]);
         return;
     }
     else if(msg["cmd"].asString() == "remove_peer" )
     {
-        if(this->get_state() != bzn::raft_state::leader)
-        {
-            bzn::message response;
-            response["error"] = ERROR_REMOVE_PEER_MUST_BE_SENT_TO_LEADER;
-            session->send_message(std::make_shared<bzn::message>(response), true);
-            return;
-        }
-
-        bzn::log_entry last_quorum_entry = this->raft_log->last_quorum_entry();
-        if(last_quorum_entry.entry_type == bzn::log_entry_type::joint_quorum)
-        {
-            bzn::message response;
-            response["error"] = MSG_ERROR_CURRENT_QUORUM_IS_JOINT;
-            session->send_message(std::make_shared<bzn::message>(response), true);
-            return;
-        }
-
-        const auto& peers = last_quorum_entry.msg["msg"]["peers"];
-        const auto& same_peer = std::find_if(
-                peers.begin()
-                , peers.end()
-                , [&](const auto& p)
-                {
-                    return p["uuid"].asString() == msg["data"]["uuid"].asString();
-                });
-        if(same_peer == peers.end())
-        {
-            bzn::message response;
-            response["error"] = ERROR_PEER_NOT_FOUND;
-            session->send_message(std::make_shared<bzn::message>(response), true);
-            return;
-        }
-
-        this->append_log_unsafe(this->create_joint_quorum_by_removing_peer(last_quorum_entry.msg, msg["data"]["uuid"].asString()), bzn::log_entry_type::joint_quorum);
+        this->handle_remove_peer(session, msg["data"]["uuid"].asString());
         return;
     }
 
@@ -738,6 +761,12 @@ raft::handle_request_append_entries_response(const bzn::message& msg, std::share
 bool
 raft::append_log_unsafe(const bzn::message& msg, const bzn::log_entry_type entry_type)
 {
+    if(this->raft_log->maximum_storage_exceeded())
+    {
+        LOG(error) << MSG_ERROR_MAXIMUM_STORAGE_EXCEEDED;
+        std::raise(SIGINT);
+    }
+
     if (this->current_state != bzn::raft_state::leader)
     {
         LOG(warning) << "not the leader, can't append log_entries!";
@@ -838,14 +867,20 @@ raft::initialize_storage_from_log(std::shared_ptr<bzn::storage_base> storage)
 std::string
 raft::entries_log_path()
 {
-    return this->state_dir  + this->get_uuid() + ".dat";
+    // Refactored as the original version was resulting in double '/' occurring
+    boost::filesystem::path out{this->state_dir};
+    out.append(this->get_uuid()+ ".dat");
+    return out.string();
 }
 
 
 std::string
 raft::state_path()
 {
-    return this->state_dir + this->get_uuid() + ".state";
+    // Refactored as the original version was resulting in double '/' occurring
+    boost::filesystem::path out{this->state_dir};
+    out.append(this->get_uuid() + ".state");
+    return out.string();
 }
 
 

--- a/raft/raft.hpp
+++ b/raft/raft.hpp
@@ -47,7 +47,7 @@ namespace bzn
     {
     public:
         raft(std::shared_ptr<bzn::asio::io_context_base> io_context, std::shared_ptr<bzn::node_base> node,
-             const bzn::peers_list_t& peers, bzn::uuid_t uuid, const std::string state_dir);
+             const bzn::peers_list_t& peers, bzn::uuid_t uuid, const std::string state_dir, const size_t maximum_raft_storage = bzn::raft_log::DEFAULT_MAX_STORAGE_SIZE);
 
         bzn::raft_state get_state() override;
 
@@ -109,6 +109,9 @@ namespace bzn
         void handle_ws_append_entries(const bzn::message& msg, std::shared_ptr<bzn::session_base> session);
 
         void update_raft_state(uint32_t term, bzn::raft_state state);
+
+        void handle_add_peer(std::shared_ptr<bzn::session_base> session, const bzn::message& peer);
+        void handle_remove_peer(std::shared_ptr<bzn::session_base> session, const std::string& uuid);
 
         // helpers...
         void get_raft_timeout_scale();

--- a/raft/raft.hpp
+++ b/raft/raft.hpp
@@ -48,7 +48,7 @@ namespace bzn
     {
     public:
         raft(std::shared_ptr<bzn::asio::io_context_base> io_context, std::shared_ptr<bzn::node_base> node,
-             const bzn::peers_list_t& peers, bzn::uuid_t uuid, const std::string state_dir, const size_t maximum_raft_storage = bzn::raft_log::DEFAULT_MAX_STORAGE_SIZE);
+             const bzn::peers_list_t& peers, bzn::uuid_t uuid, const std::string state_dir, size_t maximum_raft_storage = bzn::raft_log::DEFAULT_MAX_STORAGE_SIZE);
 
         bzn::raft_state get_state() override;
 

--- a/raft/raft.hpp
+++ b/raft/raft.hpp
@@ -35,6 +35,7 @@ namespace
     const std::string ERROR_REMOVE_PEER_MUST_BE_SENT_TO_LEADER = "ERROR_REMOVE_PEER_MUST_BE_SENT_TO_LEADER";
     const std::string MSG_ERROR_CURRENT_QUORUM_IS_JOINT = "A peer cannot be added or removed until the last quorum change request has been processed.";
     const std::string ERROR_PEER_ALREADY_EXISTS = "ERROR_PEER_ALREADY_EXISTS";
+    const std::string ERROR_INVALID_UUID = "ERROR_INVALID_UUID";
     const std::string ERROR_PEER_NOT_FOUND = "ERROR_PEER_NOT_FOUND";
     const std::string ERROR_UNABLE_TO_CREATE_LOG_FILE_FOR_WRITING = "Unable to open log file for writing: ";
 }
@@ -89,6 +90,7 @@ namespace bzn
         FRIEND_TEST(raft, test_that_is_majority_returns_expected_result_for_single_and_joint_quorums);
         FRIEND_TEST(raft, test_get_active_quorum_returns_single_or_joint_quorum_appropriately);
         FRIEND_TEST(raft_test, test_that_joint_quorum_is_converted_to_single_quorum_and_committed);
+        FRIEND_TEST(raft_test, test_that_bad_add_or_remove_peer_requests_fail);
 
         void setup_peer_tracking(const bzn::peers_list_t& peers);
 

--- a/raft/raft_log.cpp
+++ b/raft/raft_log.cpp
@@ -21,8 +21,8 @@
 
 namespace bzn
 {
-    raft_log::raft_log(const std::string& log_path)
-            : entries_log_path(log_path)
+    raft_log::raft_log(const std::string& log_path, const size_t maximum_storage)
+            :  maximum_storage(maximum_storage), entries_log_path(log_path)
     {
         if(boost::filesystem::exists(this->entries_log_path))
         {
@@ -32,6 +32,7 @@ namespace bzn
             {
                 this->log_entries.emplace_back(log_entry);
             }
+            this->total_memory_used = boost::filesystem::file_size(this->entries_log_path);
         }
 
         if (this->log_entries.empty())
@@ -87,6 +88,7 @@ namespace bzn
         }
         this->log_entry_out_stream << log_entry;
         this->log_entry_out_stream.flush();
+        this->total_memory_used = this->log_entry_out_stream.tellp();
     }
 
 

--- a/raft/raft_log.hpp
+++ b/raft/raft_log.hpp
@@ -68,7 +68,7 @@ namespace bzn
 
         std::vector<log_entry> log_entries;
         size_t                  total_memory_used = 0;
-        size_t                  maximum_storage;
+        const size_t            maximum_storage;
 
         std::ofstream log_entry_out_stream;
         const std::string entries_log_path;

--- a/raft/test/raft_log_test.cpp
+++ b/raft/test/raft_log_test.cpp
@@ -16,13 +16,130 @@
 #include <mocks/mock_node_base.hpp>
 #include <mocks/mock_session_base.hpp>
 
+#include <raft/raft.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/filesystem/operations.hpp>
+
 using namespace ::testing;
+
+namespace
+{
+    boost::random::mt19937 gen;
+
+    const bzn::uuid_t TEST_NODE_UUID{"f0645cc2-476b-485d-b589-217be3ca87d5"};
+    const bzn::peers_list_t TEST_PEER_LIST{{"127.0.0.1", 8081, 80, "name1", "uuid1"},
+                                           {"127.0.0.1", 8082, 81, "name2", "uuid2"},
+                                           {"127.0.0.1", 8084, 82, "name3", TEST_NODE_UUID}};
+
+    std::string
+    generate_test_string(int n = 100)
+    {
+        std::string test_data;
+        test_data.resize(n);
+
+        boost::random::uniform_int_distribution<> dist('a', 'z');
+        for(auto& c : test_data)
+        {
+            c = (char)dist(gen);
+        }
+        return test_data;
+    }
+
+    bzn::message
+    generate_test_message()
+    {
+        bzn::message msg;
+        msg["bzn-api"] = "test";
+        msg["cmd"] = "test";
+        msg["data"] = generate_test_string(40);
+        return msg;
+    }
+
+
+    void
+    create_initial_entries_log(const std::string& path)
+    {
+        std::ofstream out(path, std::ios::out | std::ios::binary);
+        out << bzn::log_entry{bzn::log_entry_type::single_quorum, 0, 0, bzn::message{}};
+
+        for(uint32_t i=1;i<10;++i)
+        {
+            out << bzn::log_entry{bzn::log_entry_type::database, i, 1, generate_test_message()};
+        }
+        out.close();
+    }
+
+    void
+    create_state_file(const std::string& path, size_t term, size_t index)
+    {
+        std::ofstream os( path ,std::ios::out | std::ios::binary);
+        os << term << " " << index << " " <<  term;
+        os.close();
+    }
+
+
+    void
+    remove_folder(const std::string& path)
+    {
+        if(boost::filesystem::exists(path))
+        {
+            boost::filesystem::remove_all(path);
+        }
+    }
+}
+
 
 namespace bzn
 {
-    // TODO: pull logging tests out of raft tests.
-//    TEST(raft_log, test_that_something)
-//    {
-//        EXPECT_TRUE(false);
-//    }
+    TEST(raft_log, test_that_raft_log_tracks_storage_used)
+    {
+        const std::string test_path{"./raft_log_test.dat"};
+        unlink(test_path.c_str());
+
+        create_initial_entries_log(test_path);
+
+        bzn::raft_log sut(test_path);
+        EXPECT_EQ(size_t(boost::filesystem::file_size(test_path)), sut.memory_used());
+
+        for (uint32_t i = 1; i < 100; ++i)
+        {
+            sut.leader_append_entry(bzn::log_entry{bzn::log_entry_type::database, i, 1, generate_test_message()});
+        }
+        EXPECT_EQ(size_t(boost::filesystem::file_size(test_path)), sut.memory_used());
+
+        unlink(test_path.c_str());
+    }
+
+    TEST(raft_log, test_that_raft_throws_on_start_when_max_storage_is_exceeded)
+    {
+        const size_t MAX_STORAGE_BYTES = 1000;
+        const std::string TEST_STATE_DIR = "./.raft_test_state";
+        const std::string ENTRIES_LOG = TEST_STATE_DIR + "/" + TEST_NODE_UUID + ".dat";
+        const std::string STATE_LOG = TEST_STATE_DIR + "/" + TEST_NODE_UUID + ".state";
+        remove_folder(TEST_STATE_DIR);
+
+        boost::filesystem::create_directory(TEST_STATE_DIR);
+
+
+        create_initial_entries_log(ENTRIES_LOG);
+        create_state_file(STATE_LOG, 1, 9);
+
+        try
+        {
+            bzn::raft(
+                    std::make_shared<NiceMock<bzn::asio::Mockio_context_base>>()
+                    , nullptr
+                    , TEST_PEER_LIST
+                    , TEST_NODE_UUID
+                    , TEST_STATE_DIR
+                    , MAX_STORAGE_BYTES);
+            FAIL() << "raft with entry log size exceeding max storage size should have thrown an exception";
+        }
+        catch(const std::runtime_error& e)
+        {
+            EXPECT_EQ(e.what(), bzn::MSG_ERROR_MAXIMUM_STORAGE_EXCEEDED);
+        }
+        remove_folder(TEST_STATE_DIR);
+    }
 }

--- a/raft/test/raft_test.cpp
+++ b/raft/test/raft_test.cpp
@@ -89,10 +89,6 @@ namespace
             }
             boost::filesystem::create_directory(TEST_STATE_DIR);
 
-
-
-
-
             if(boost::filesystem::exists("./.state"))
             {
                 boost::filesystem::remove_all("./.state");

--- a/swarm/main.cpp
+++ b/swarm/main.cpp
@@ -228,7 +228,7 @@ main(int argc, const char* argv[])
         auto websocket = std::make_shared<bzn::beast::websocket>();
 
         auto node = std::make_shared<bzn::node>(io_context, websocket, options.get_ws_idle_timeout(), boost::asio::ip::tcp::endpoint{options.get_listener()});
-        auto raft = std::make_shared<bzn::raft>(io_context, node, peers.get_peers(), options.get_uuid(), options.get_state_dir());
+        auto raft = std::make_shared<bzn::raft>(io_context, node, peers.get_peers(), options.get_uuid(), options.get_state_dir(), options.get_max_storage());
         auto storage = std::make_shared<bzn::storage>();
         auto crud = std::make_shared<bzn::crud>(node, raft, storage, std::make_shared<bzn::subscription_manager>(io_context));
         auto audit = std::make_shared<bzn::audit>(io_context, node, options.get_monitor_endpoint(io_context), options.get_uuid(), options.get_audit_mem_size());


### PR DESCRIPTION
…will throw a run time exception which shold result in an exit

The sketchiest change is in
  raft::append_log_unsafe
where if raft ever exceeds it's maximum storage limit it will simply call raise(SIGINT) after throwing up an error message on the console. That occurs at the moment an append entry happens when the max storage has already been exceed.

There are also a few refactorings:
- pulled out add_peer and remove_peer remove functionality into their own methods
- after some pain with double '/' in the raft::entries_log_path() and raft::state_path() methods, changed them to use boos::filesystem
- 
