### PR TITLE
KEP-488: Ensure that a 4 node swarm cannot reach consensus with only …

### DIFF
--- a/raft/raft.hpp
+++ b/raft/raft.hpp
@@ -91,6 +91,7 @@ namespace bzn
         FRIEND_TEST(raft, test_get_active_quorum_returns_single_or_joint_quorum_appropriately);
         FRIEND_TEST(raft_test, test_that_joint_quorum_is_converted_to_single_quorum_and_committed);
         FRIEND_TEST(raft_test, test_that_bad_add_or_remove_peer_requests_fail);
+        FRIEND_TEST(raft_test, test_that_a_four_node_swarm_cannot_reach_consensus_with_two_nodes);
 
         void setup_peer_tracking(const bzn::peers_list_t& peers);
 


### PR DESCRIPTION
…2 votes

Here's the unit test that shows that 2 yes votes out of 4 will not form a consensus. I set up a raft instant with 3 peers, and then have that peer become a candidate and tally votes.