### PR TITLE
KEP-536 Moved the check for max storage exceeded up the stack from ap…

### DIFF
--- a/raft/raft.hpp
+++ b/raft/raft.hpp
@@ -148,6 +148,8 @@ namespace bzn
         void notify_commit(size_t log_index, const std::string& operation);
         bzn::log_entry_type deduce_type_from_message(const bzn::message& message);
 
+        void shutdown_on_exceeded_max_storage(bool do_throw = false);
+
         // raft state...
         bzn::raft_state current_state = raft_state::follower;
         uint32_t        current_term = 0;


### PR DESCRIPTION
…pend_log_unsafe to handle_ws_raft_messages

The problem was that the append_log_unsafe method was only being called by the leader. So if a follower had exceeded it's max storage it would happily append messages using a different path (which I think may be a problem we should look at, but since we are doing away with raft...)

I combined the duplicated code where we bail on exceeded storage into a nice method and called it on raft instantiation and at the start of handle_ws_raft_messages before we attempt to do any work.

NOTE: I accidentally put KEP-563 in the git log, it should be KEP-536.