### PR TITLE
KEP-544: Refactor options module, config file options displayed on --…

### DIFF
--- a/options/CMakeLists.txt
+++ b/options/CMakeLists.txt
@@ -3,6 +3,8 @@ add_library(options STATIC
         options.cpp
         options.hpp
         options_base.hpp
+        simple_options.cpp
+        simple_options.hpp
         )
 
 target_link_libraries(options)

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -13,104 +13,33 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #include <options/options.hpp>
-#include <boost/program_options.hpp>
 #include <boost/lexical_cast.hpp>
 #include <regex>
-#include <iostream>
-#include <fstream>
-#include <swarm_version.hpp>
+#include <cstdint>
 
-#ifndef __APPLE__
-#include <optional>
-#else
-#include <experimental/optional>
-#endif
-
-namespace po = boost::program_options;
 using namespace bzn;
-
-
-namespace
-{
-    const std::string DEFAULT_CONFIG_FILE = "bluzelle.json";
-    const std::string AUDIT_MEM_SIZE_KEY = "audit_mem_size";
-    const std::string BOOTSTRAP_PEERS_FILE_KEY = "bootstrap_file";
-    const std::string BOOTSTRAP_PEERS_URL_KEY = "bootstrap_url";
-    const std::string DEBUG_LOGGING_KEY = "debug_logging";
-    const std::string ETHERERUM_IO_API_TOKEN_KEY = "ethereum_io_api_token";
-    const std::string ETHERERUM_KEY = "ethereum";
-    const std::string HTTP_PORT_KEY = "http_port";
-    const std::string LISTENER_ADDRESS_KEY = "listener_address";
-    const std::string LISTENER_PORT_KEY = "listener_port";
-    const std::string LOG_TO_STDOUT_KEY = "log_to_stdout";
-    const std::string LOGFILE_DIR_KEY = "logfile_dir";
-    const std::string LOGFILE_MAX_SIZE_KEY = "logfile_max_size";
-    const std::string LOGFILE_ROTATION_SIZE_KEY = "logfile_rotation_size";
-    const std::string MAX_STORAGE_KEY = "max_storage";
-    const std::string MONITOR_ADDRESS_KEY = "monitor_address";
-    const std::string MONITOR_PORT_KEY = "monitor_port";
-    const std::string NODE_UUID_KEY = "uuid";
-    const std::string PBFT_ENABLED_KEY = "use_pbft";
-    const std::string STATE_DIR_KEY = "state_dir";
-    const std::string WS_IDLE_TIMEOUT_KEY = "ws_idle_timeout";
-
-    // this is 10k error strings in a vector, which is pessimistically 10MB, which is small enough that no one should mind
-    const size_t DEFAULT_AUDIT_MEM_SIZE = 10000;
-
-    const std::string DEFAULT_STATE_DIR = "./.state/";
-
-    // Default logfile director
-    const std::string DEFAULT_LOGFILE_DIR = "logs/";
-
-    // The default maximum allowed storage for a node is 2G
-    const size_t DEFAULT_MAX_STORAGE_SIZE = 2147483648;
-
-    // Default log size before rotation
-    const size_t DEFAULT_LOGFILE_ROATION_SIZE = 65536;
-
-    // Default max log files before deletion
-    const size_t DEFAULT_LOGFILE_MAX_SIZE = 524288;
-
-    // Default http server port
-    const uint16_t DEFAULT_HTTP_PORT = 8080;
-
-    // https://stackoverflow.com/questions/8899069
-    bool
-    is_hex_notation(std::string const& s)
-    {
-        return s.compare(0, 2, "0x") == 0
-               && s.size() > 2
-               && s.find_first_not_of("0123456789abcdefABCDEF", 2) == std::string::npos;
-    }
-}
-
+using namespace bzn::option_names;
 
 bool
 options::parse_command_line(int argc, const char* argv[])
 {
-    // no args then load default options...
-    if (argc == 1)
-    {
-        this->load(DEFAULT_CONFIG_FILE);
-        return this->validate();
-    }
-
-    // validate passed args...
-    if (this->parse(argc, argv))
-    {
-        return this->validate();
-    }
-    return false;
+    return this->raw_opts.parse(argc, argv);
 }
 
+const simple_options&
+options::get_simple_options() const
+{
+    return this->raw_opts;
+}
 
 boost::asio::ip::tcp::endpoint
 options::get_listener() const
 {
     try
     {
-        auto ep = boost::asio::ip::tcp::endpoint{boost::asio::ip::address::from_string(this->config_data[LISTENER_ADDRESS_KEY].asString()),
-                   uint16_t(this->config_data[LISTENER_PORT_KEY].asUInt())};
+        auto ep = boost::asio::ip::tcp::endpoint{
+            boost::asio::ip::address::from_string(this->raw_opts.get<std::string>(LISTENER_ADDRESS)),
+            this->raw_opts.get<uint16_t>(LISTENER_PORT)};
 
         return ep;
     }
@@ -124,14 +53,14 @@ options::get_listener() const
 bzn::optional<boost::asio::ip::udp::endpoint>
 options::get_monitor_endpoint(std::shared_ptr<bzn::asio::io_context_base> context) const
 {
-    if (this->config_data.isMember(MONITOR_PORT_KEY) && this->config_data.isMember(MONITOR_ADDRESS_KEY))
+    if (this->raw_opts.has(MONITOR_PORT) && this->raw_opts.has(MONITOR_ADDRESS))
     {
         try
         {
             boost::asio::ip::udp::resolver resolver(context->get_io_context());
             auto eps = resolver.resolve(boost::asio::ip::udp::v4(),
-                                        this->config_data[MONITOR_ADDRESS_KEY].asString(),
-                                        std::to_string(this->config_data[MONITOR_PORT_KEY].asUInt()));
+                                        this->raw_opts.get<std::string>(MONITOR_ADDRESS),
+                                        std::to_string(this->raw_opts.get<uint16_t>(MONITOR_PORT)));
 
             return bzn::optional<boost::asio::ip::udp::endpoint>{*eps.begin()};
         }
@@ -150,341 +79,147 @@ options::get_monitor_endpoint(std::shared_ptr<bzn::asio::io_context_base> contex
 bool
 options::pbft_enabled() const
 {
-    return this->config_data.isMember(PBFT_ENABLED_KEY) && this->config_data[PBFT_ENABLED_KEY].asBool();
+    //TODO: Remove this
+    return this->raw_opts.get<bool>(PBFT_ENABLED);
 }
 
 
 std::string
 options::get_ethererum_address() const
 {
-    return this->config_data[ETHERERUM_KEY].asString();
+    //TODO: Remove this
+    return this->raw_opts.get<std::string>(ETHERERUM);
 }
 
 
 std::string
 options::get_ethererum_io_api_token() const
 {
-    return this->config_data[ETHERERUM_IO_API_TOKEN_KEY].asString();
+    //TODO: Remove this
+    return this->raw_opts.get<std::string>(ETHERERUM_IO_API_TOKEN);
 }
 
 
 std::string
 options::get_bootstrap_peers_file() const
 {
-    return this->config_data[BOOTSTRAP_PEERS_FILE_KEY].asString();
+    //TODO: Remove this
+    return this->raw_opts.get<std::string>(BOOTSTRAP_PEERS_FILE);
 }
 
 
 std::string
 options::get_bootstrap_peers_url() const
 {
-    return this->config_data[BOOTSTRAP_PEERS_URL_KEY].asString();
+    //TODO: Remove this
+    return this->raw_opts.get<std::string>(BOOTSTRAP_PEERS_URL);
 }
 
 bzn::uuid_t
 options::get_uuid() const
 {
-    return this->config_data[NODE_UUID_KEY].asString();
+    //TODO: Remove this
+    return this->raw_opts.get<std::string>(NODE_UUID);
 }
-
-
-void
-options::load(const std::string& config_file)
-{
-    try
-    {
-        std::ifstream ifile(config_file);
-        ifile.exceptions(std::ios::failbit);
-
-        Json::Reader reader;
-        if (!reader.parse(ifile, this->config_data))
-        {
-            throw std::runtime_error("Failed to parse: " + config_file + " : " + reader.getFormattedErrorMessages());
-        }
-    }
-    catch (std::exception& /*e*/)
-    {
-        throw std::runtime_error("Failed to load: " + config_file + " : " + strerror(errno));
-    }
-}
-
-
-bool
-options::validate()
-{
-    // validate listener...
-    if (!this->config_data.isMember(LISTENER_ADDRESS_KEY))
-    {
-        std::cerr << "Missing listener address entry!" << '\n';
-        return false;
-    }
-
-    // validate port...
-    if (!this->config_data.isMember(LISTENER_PORT_KEY))
-    {
-        std::cerr << "Missing listener port entry!" << '\n';
-        return false;
-    }
-    else
-    {
-        auto port = this->config_data[LISTENER_PORT_KEY].asUInt();
-
-        // todo: why do care what port is being used?
-        if (!(port >= 49152 && port <= 65535))
-        {
-            std::cerr << "Invalid listener port entry: " << std::to_string(port) << '\n';
-            return false;
-        }
-    }
-
-    // validate Ethereum address...
-    if (!this->config_data.isMember(ETHERERUM_KEY))
-    {
-        std::cerr << "Missing Ethereum address entry!" << '\n';
-        return false;
-    }
-    else
-    {
-        if (!is_hex_notation(this->config_data[ETHERERUM_KEY].asString()))
-        {
-            std::cerr << "Invalid Ethereum address: " << this->config_data[ETHERERUM_KEY].asString() << '\n';
-            return false;
-        }
-    }
-
-    if (!this->config_data.isMember(ETHERERUM_IO_API_TOKEN_KEY))
-    {
-        std::cerr << "Missing Ethereum IO API token entry!" << '\n';
-        return false;
-    }
-
-    if (!this->config_data.isMember(NODE_UUID_KEY))
-    {
-        std::cerr << "Missing UUID entry!" << '\n';
-        return false;
-    }
-
-    if (!this->config_data.isMember(BOOTSTRAP_PEERS_URL_KEY) && !this->config_data.isMember(BOOTSTRAP_PEERS_FILE_KEY))
-    {
-        std::cerr << "Missing Bootstrap URL or FILE entry!" << '\n';
-        return false;
-    }
-
-    if (this->config_data.isMember(MONITOR_PORT_KEY) && this->config_data.isMember(MONITOR_ADDRESS_KEY))
-    {
-        LOG(info) << "No monitor address provided; will not send monitor packets";
-    }
-
-    return true;
-}
-
 
 bool
 options::get_debug_logging() const
 {
-    if (this->config_data.isMember(DEBUG_LOGGING_KEY))
-    {
-        return this->config_data[DEBUG_LOGGING_KEY].asBool();
-    }
-
-    return false;
+    //TODO: Remove this
+    return this->raw_opts.get<bool>(DEBUG_LOGGING);
 }
 
 
 bool
 options::get_log_to_stdout() const
 {
-    if (this->config_data.isMember(LOG_TO_STDOUT_KEY))
-    {
-        return this->config_data[LOG_TO_STDOUT_KEY].asBool();
-    }
-
-    return false;
+    //TODO: Remove this
+    return this->raw_opts.get<bool>(LOG_TO_STDOUT);
 }
 
 
 std::chrono::seconds
 options::get_ws_idle_timeout() const
 {
-    return std::chrono::seconds(this->config_data[WS_IDLE_TIMEOUT_KEY].asUInt64());
+    //TODO: Remove this?
+    return std::chrono::seconds(raw_opts.get<uint64_t>(WS_IDLE_TIMEOUT));
 }
 
 
 size_t
 options::get_audit_mem_size() const
 {
-    if (this->config_data.isMember(AUDIT_MEM_SIZE_KEY))
-    {
-        return this->config_data[AUDIT_MEM_SIZE_KEY].asUInt();
-    }
-
-    return DEFAULT_AUDIT_MEM_SIZE;
+    //TODO: Remove this
+    return this->raw_opts.get<size_t>(AUDIT_MEM_SIZE);
 }
 
 
 std::string
 options::get_state_dir() const
 {
-    if (this->config_data.isMember(STATE_DIR_KEY))
-    {
-        return this->config_data[STATE_DIR_KEY].asString();
-    }
-
-    return DEFAULT_STATE_DIR;
+    //TODO: Remove this
+    return this->raw_opts.get<std::string>(STATE_DIR);
 }
 
 
 std::string
 options::get_logfile_dir() const
 {
-    if (this->config_data.isMember(LOGFILE_DIR_KEY))
-    {
-        return this->config_data[LOGFILE_DIR_KEY].asString();
-    }
-
-    return DEFAULT_LOGFILE_DIR;
-}
-
-
-bool
-options::parse(int argc, const char* argv[])
-{
-    po::options_description desc("Options");
-
-    // variables the map will fill...
-    std::string config_file;
-
-    desc.add_options()
-        ("help,h",    "Shows this information")
-        ("version,v", "Show the application's version")
-        ("config,c",  po::value<std::string>(&config_file), "Path to configuration file");
-
-    po::variables_map vm;
-
-    try
-    {
-        po::store(po::parse_command_line(argc, argv, desc), vm);
-
-        if (vm.count("version"))
-        {
-            std::cout << "Bluzelle" << ": v" << SWARM_VERSION << std::endl;
-            return false;
-        }
-
-        if (vm.count("help") || vm.count("config") == 0)
-        {
-            std::cout << "Usage:" << '\n'
-                      << "  " << "bluzelle" << " [OPTION]" << '\n'
-                      << '\n' << desc << '\n';
-            return false;
-        }
-
-        po::notify(vm);
-
-        this->load(config_file);
-        return true;
-    }
-    catch (po::error& e)
-    {
-        std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-        std::cerr << desc << std::endl;
-        return false;
-    }
-    catch (std::exception& e)
-    {
-        std::cerr << "Unhandled Exception: " << e.what() << ", application will now exit" << std::endl;
-        return false;
-    }
-
-    return true;
+    //TODO: Remove this
+    return this->raw_opts.get<std::string>(LOGFILE_DIR);
 }
 
 
 size_t
 options::get_max_storage() const
 {
-    size_t value = DEFAULT_MAX_STORAGE_SIZE;
-
-    if (auto conf_value = this->parse_size(MAX_STORAGE_KEY))
-    {
-        // todo: use operator* to workaround clang bug...
-        value = *conf_value;
-    }
-    return value;
+    return this->parse_size(this->raw_opts.get<std::string>(MAX_STORAGE));
 }
 
 
 size_t
 options::get_logfile_rotation_size() const
 {
-    size_t value = DEFAULT_LOGFILE_ROATION_SIZE;
-
-    if (auto conf_value = this->parse_size(LOGFILE_ROTATION_SIZE_KEY))
-    {
-        // todo: use operator* to workaround clang bug...
-        value = *conf_value;
-    }
-    return value;
+    return this->parse_size(this->raw_opts.get<std::string>(LOGFILE_ROTATION_SIZE));
 }
 
 
 size_t
 options::get_logfile_max_size() const
 {
-    size_t value = DEFAULT_LOGFILE_MAX_SIZE;
-
-    if (auto conf_value = this->parse_size(LOGFILE_MAX_SIZE_KEY))
-    {
-        // todo: use operator* to workaround clang bug...
-        value = *conf_value;
-    }
-    return value;
+    return this->parse_size(this->raw_opts.get<std::string>(LOGFILE_MAX_SIZE));
 }
 
 
-#ifndef __APPLE__
-std::optional<size_t>
-#else
-std::experimental::optional<size_t>
-#endif
-options::parse_size(const std::string& key) const
+size_t
+options::parse_size(const std::string& max_value) const
 {
-    if (this->config_data.isMember(key))
+    const std::regex expr{"(\\d+)([K,M,G,T]?[B]?)"};
+
+    std::smatch base_match;
+    if (std::regex_match(max_value, base_match, expr))
     {
-        const std::string max_value{this->config_data[key].asString()};
+        std::string suffix = base_match[2];
 
-        const std::regex expr{"(\\d+)([K,M,G,T]?[B]?)"};
-
-        std::smatch base_match;
-        if (std::regex_match(max_value, base_match, expr))
-        {
-            std::string suffix = base_match[2];
-
-            return boost::lexical_cast<size_t>(base_match[1])
-                   * utils::BYTE_SUFFIXES.at(suffix.empty() ? 'B' : suffix[0]);
-        }
-
-        throw std::runtime_error(std::string("\nUnable to parse \"" + key + "\" value from options: " + max_value));
+        return boost::lexical_cast<size_t>(base_match[1])
+               * utils::BYTE_SUFFIXES.at(suffix.empty() ? 'B' : suffix[0]);
     }
 
-    return {}; /*std::nullopt*/
+    throw std::runtime_error(std::string("\nUnable to parse size value from options: " + max_value));
 }
 
 
 uint16_t
 options::get_http_port() const
 {
-    if (this->config_data.isMember(HTTP_PORT_KEY))
-    {
-        return this->config_data[HTTP_PORT_KEY].asInt();
-    }
-
-    return DEFAULT_HTTP_PORT;
+    //TODO: Remove this
+    return this->raw_opts.get<uint16_t>(HTTP_PORT);
 }
 
 
 bool 
 options::peer_validation_enabled() const
 {
-    return this->config_data.isMember(PEER_VALIDATION_ENABLED_KEY) && this->config_data[PEER_VALIDATION_ENABLED_KEY].asBool();
-} 
+    //TODO: Remove this
+    return this->raw_opts.get<bool>(PEER_VALIDATION_ENABLED);
+}

--- a/options/options.hpp
+++ b/options/options.hpp
@@ -23,6 +23,8 @@ namespace bzn
     class options final : public bzn::options_base
     {
     public:
+        const simple_options& get_simple_options() const override;
+
         bool parse_command_line(int argc, const char* argv[]);
 
         boost::asio::ip::tcp::endpoint get_listener() const override;
@@ -64,21 +66,9 @@ namespace bzn
         bool peer_validation_enabled() const override;
 
     private:
-        bool parse(int argc, const char* argv[]);
+        size_t parse_size(const std::string& key) const;
 
-        void load(const std::string& config_file);
-
-        bool validate();
-
-        // todo: nuke once Apple updates clang!
-#ifndef __APPLE__
-        std::optional<size_t>
-#else
-        std::experimental::optional<size_t>
-#endif
-        parse_size(const std::string& key) const;
-
-        Json::Value config_data;
+        simple_options raw_opts;
 
     };
 

--- a/options/options_base.hpp
+++ b/options/options_base.hpp
@@ -19,13 +19,12 @@
 #include <include/bluzelle.hpp>
 #include <include/optional.hpp>
 #include <include/boost_asio_beast.hpp>
+#include <options/simple_options.hpp>
 #include <string>
 #include <map>
 
 namespace bzn
 {
-    const std::string PEER_VALIDATION_ENABLED_KEY = "peer_validation_enabled";
-
     // Suffixes for the max size parser.
     namespace utils
     {
@@ -40,6 +39,11 @@ namespace bzn
     {
     public:
         virtual ~options_base() = default;
+
+        /**
+         * @return the raw_options container for accessing simple options
+         */
+        virtual const simple_options& get_simple_options() const = 0;
 
         /**
          * Get the address and port for the node to listen on

--- a/options/simple_options.cpp
+++ b/options/simple_options.cpp
@@ -1,0 +1,279 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#include <options/simple_options.hpp>
+#include <json/json.h>
+#include <iostream>
+#include <fstream>
+#include <swarm_version.hpp>
+#include <boost/algorithm/string.hpp>
+
+using namespace bzn;
+using namespace bzn::option_names;
+namespace po = boost::program_options;
+
+namespace
+{
+    const std::string DEFAULT_CONFIG_FILE = "bluzelle.json";
+
+    // https://stackoverflow.com/questions/8899069
+    bool
+    is_hex_notation(std::string const& s)
+    {
+        return s.compare(0, 2, "0x") == 0
+               && s.size() > 2
+               && s.find_first_not_of("0123456789abcdefABCDEF", 2) == std::string::npos;
+    }
+}
+
+simple_options::simple_options()
+        : options_root("Core configuration")
+{
+}
+
+bool
+simple_options::parse(int argc, const char* argv[])
+{
+    this->build_options();
+    return this->handle_command_line_options(argc, argv) && this->handle_config_file_options() && this->validate_options();
+}
+
+void
+simple_options::build_options()
+{
+    this->options_root.add_options()
+                (BOOTSTRAP_PEERS_FILE.c_str(),
+                        po::value<std::string>(),
+                        "file path for bootstrap peers list")
+                (BOOTSTRAP_PEERS_URL.c_str(),
+                        po::value<std::string>(),
+                        "url for bootstrap peers list")
+                (ETHERERUM_IO_API_TOKEN.c_str(),
+                        po::value<std::string>()->required(),
+                        "ethereum io api token")
+                (ETHERERUM.c_str(),
+                        po::value<std::string>()->required(),
+                        "ethereum address")
+                (HTTP_PORT.c_str(),
+                        po::value<uint16_t>()->default_value(8080),
+                        "port for http server")
+                (LISTENER_ADDRESS.c_str(),
+                        po::value<std::string>()->required(),
+                        "listener address for consensus node")
+                (LISTENER_PORT.c_str(),
+                        po::value<uint16_t>()->required(),
+                        "port for consensus node")
+                (MAX_STORAGE.c_str(),
+                         po::value<std::string>()->default_value("2G"),
+                        "maximum db storage on this node (bytes)")
+                (NODE_UUID.c_str(),
+                        po::value<std::string>()->required(),
+                        "uuid of this node")
+                (STATE_DIR.c_str(),
+                        po::value<std::string>()->default_value("./.state/"),
+                        "location for state files")
+                (WS_IDLE_TIMEOUT.c_str(),
+                        po::value<uint64_t>(),
+                        "websocket idle timeout");
+
+    po::options_description logging("Logging");
+    logging.add_options()
+                (LOG_TO_STDOUT.c_str(),
+                        po::value<bool>()->default_value(false),
+                        "log to stdout")
+                (LOGFILE_DIR.c_str(),
+                        po::value<std::string>()->default_value("logs/"),
+                        "directory for log files")
+                (LOGFILE_MAX_SIZE.c_str(),
+                        po::value<std::string>()->default_value("512K"),
+                        "maximum size for log files")
+                (LOGFILE_ROTATION_SIZE.c_str(),
+                        po::value<std::string>()->default_value("64K"),
+                        "size at which to rotate log files")
+                (DEBUG_LOGGING.c_str(),
+                        po::value<bool>()->default_value(false),
+                        "enable debug logging");
+    this->options_root.add(logging);
+
+    po::options_description audit("Audit");
+    audit.add_options()
+                (AUDIT_MEM_SIZE.c_str(),
+                        po::value<size_t>()->default_value(10000),
+                        "max size of audit datastructures")
+                (MONITOR_ADDRESS.c_str(),
+                        po::value<std::string>(),
+                        "address of stats.d listener for audit module")
+                (MONITOR_PORT.c_str(),
+                        po::value<uint16_t>(),
+                        "port of stats.d listener for audit module");
+    this->options_root.add(audit);
+
+    po::options_description experimental("Experimental");
+    experimental.add_options()
+                (AUDIT_MEM_SIZE.c_str(),
+                        po::value<size_t>()->default_value(10000),
+                        "max size of audit datastructures")
+                (PBFT_ENABLED.c_str(),
+                        po::value<bool>()->default_value(false),
+                        "use pbft consensus instead of raft (experimental)")
+                (PEER_VALIDATION_ENABLED.c_str(),
+                        po::value<bool>()->default_value(false),
+                        "require signed key for new peers to join swarm");
+    this->options_root.add(experimental);
+
+}
+
+bool
+simple_options::validate_options()
+{
+    bool errors = false;
+
+    // Boost will enforce required-ness and types of options, we only need to validate more complex constraints
+
+    auto port = this->get<uint16_t>(LISTENER_PORT);
+    if (port <= 1024)
+    {
+        std::cerr << "Invalid listener port " << std::to_string(port);
+        errors = true;
+    }
+
+    auto eth_address = this->get<std::string>(ETHERERUM);
+    if (!is_hex_notation(eth_address))
+    {
+        std::cerr << "Invalid Ethereum address " << eth_address;
+        errors = true;
+    }
+
+    if (! (this->has(BOOTSTRAP_PEERS_FILE) || this->has(BOOTSTRAP_PEERS_URL)))
+    {
+        std::cerr << "Bootstrap peers source not specified";
+        errors = true;
+    }
+
+    return !errors;
+}
+
+bool
+simple_options::handle_config_file_options()
+{
+    Json::Value json;
+
+    try
+    {
+        std::ifstream ifile(config_file);
+        ifile.exceptions(std::ios::failbit);
+
+        Json::Reader reader;
+        if (!reader.parse(ifile, json))
+        {
+            throw std::runtime_error("Failed to parse: " + config_file + " : " + reader.getFormattedErrorMessages());
+        }
+    }
+    catch (std::exception& /*e*/)
+    {
+        throw std::runtime_error("Failed to load: " + config_file + " : " + strerror(errno));
+    }
+
+    if(!json.isObject())
+    {
+        throw std::runtime_error("Config file should be an object");
+    }
+
+    po::parsed_options parsed(&(this->options_root));
+
+    for(const auto& name : json.getMemberNames())
+    {
+        const auto& json_val = json[name];
+
+        boost::program_options::basic_option<char> opt;
+        opt.string_key = name;
+
+        if (json_val.isString())
+        {
+            opt.value.push_back(json_val.asString());
+        }
+        else
+        {
+            // If it's not a string, then it should be a bool or a number, so we can let boost parse it
+            auto option_value = json_val.toStyledString();
+            boost::trim(option_value); // jsoncpp sometimes includes a trailing newline here
+
+            opt.value.push_back(option_value);
+        }
+
+        parsed.options.push_back(opt);
+    }
+
+    boost::program_options::store(parsed, vm);
+    boost::program_options::notify(vm);
+
+    return true;
+}
+
+bool
+simple_options::handle_command_line_options(int argc, const char* argv[])
+{
+    boost::program_options::options_description desc("Command line options");
+
+    desc.add_options()
+                ("help,h",    "Shows this information")
+                ("version,v", "Show the application's version")
+                ("config,c",  po::value<std::string>(&this->config_file)->default_value(DEFAULT_CONFIG_FILE), "Path to configuration file");
+
+    po::variables_map vm;
+
+    try
+    {
+        po::store(po::parse_command_line(argc, argv, desc), vm);
+
+        if (vm.count("version"))
+        {
+            std::cout << "Bluzelle" << ": v" << SWARM_VERSION << std::endl;
+            return false;
+        }
+
+        if (vm.count("help") || vm.count("config") == 0)
+        {
+            std::cout << "Usage:" << '\n'
+                      << "  " << "bluzelle" << " [OPTION]" << '\n'
+                      << '\n' << desc << '\n'
+
+                      << "Config file options (specified as keys in JSON object, not command line arguments)" << '\n'
+                      << '\n' << this->options_root << '\n';
+
+            return false;
+        }
+
+        po::notify(vm);
+
+        return true;
+    }
+    catch (po::error& e)
+    {
+        std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
+        std::cerr << desc << std::endl;
+        return false;
+    }
+    catch (std::exception& e)
+    {
+        std::cerr << "Unhandled Exception: " << e.what() << ", application will now exit" << std::endl;
+        return false;
+    }
+}
+
+bool
+simple_options::has(const std::string& option_name) const
+{
+    return this->vm.count(option_name) > 0;
+}

--- a/options/simple_options.hpp
+++ b/options/simple_options.hpp
@@ -1,0 +1,91 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <boost/program_options.hpp>
+#include <string>
+
+namespace bzn::option_names
+{
+    const std::string AUDIT_MEM_SIZE = "audit_mem_size";
+    const std::string BOOTSTRAP_PEERS_FILE = "bootstrap_file";
+    const std::string BOOTSTRAP_PEERS_URL = "bootstrap_url";
+    const std::string DEBUG_LOGGING = "debug_logging";
+    const std::string ETHERERUM_IO_API_TOKEN = "ethereum_io_api_token";
+    const std::string ETHERERUM = "ethereum";
+    const std::string HTTP_PORT = "http_port";
+    const std::string LISTENER_ADDRESS = "listener_address";
+    const std::string LISTENER_PORT = "listener_port";
+    const std::string LOG_TO_STDOUT = "log_to_stdout";
+    const std::string LOGFILE_DIR = "logfile_dir";
+    const std::string LOGFILE_MAX_SIZE = "logfile_max_size";
+    const std::string LOGFILE_ROTATION_SIZE = "logfile_rotation_size";
+    const std::string MAX_STORAGE = "max_storage";
+    const std::string MONITOR_ADDRESS = "monitor_address";
+    const std::string MONITOR_PORT = "monitor_port";
+    const std::string NODE_UUID = "uuid";
+    const std::string PBFT_ENABLED = "use_pbft";
+    const std::string STATE_DIR = "state_dir";
+    const std::string WS_IDLE_TIMEOUT = "ws_idle_timeout";
+    const std::string PEER_VALIDATION_ENABLED = "peer_validation_enabled";
+
+}
+
+namespace bzn
+{
+    class simple_options
+    {
+    public:
+        simple_options();
+
+        /*
+         * Read command line to find location of config file, read config file for everything else
+         */
+        bool parse(int argc, const char* argv[]);
+
+        /*
+         * Get the value of a particular option (options defined in bzn::options) with a particular type
+         */
+        template<typename T>
+        T
+        get(const std::string& option_name) const
+        {
+            if (this->has(option_name))
+            {
+                return this->vm[option_name].as<T>();
+            }
+            else
+            {
+                // T is a string and option_name doesn't exist, the lookup will throw an exception
+                return T();
+            }
+        }
+
+        /*
+         * Do we have a value for an option (either explicit or default)
+         */
+        bool has(const std::string& option_name) const;
+
+    private:
+        void build_options();
+        bool validate_options();
+        bool handle_command_line_options(int argc, const char* argv[]);
+        bool handle_config_file_options();
+
+        std::string config_file;
+        boost::program_options::options_description options_root;
+        boost::program_options::variables_map vm;
+    };
+}


### PR DESCRIPTION
…help

The goal of the refactoring here is to remove the code duplication in options, where each option requires a new method (with forward declarations and testing) in addition to the definition of the option itself.

My strategy is to implement a new class simple_options, which just thinks about options as name:type:default_value tuples. The options class now wraps a simple_options, and implements more advanced logic where required - such as requiring that one of two options be present, or parsing size limits. Going forward, options that do not require more logic can be accessed as options->get_simple_options.get<type>(option_name). The existing methods on options.cpp that just do option lookup without additional logic are maintained for now to keep the interface consistent (and avoid making this a terribly messy merge), but they can be removed going forward.


