### PR TITLE
KEP-616: Out of file handlers

### DIFF
--- a/options/simple_options.cpp
+++ b/options/simple_options.cpp
@@ -108,6 +108,9 @@ simple_options::build_options()
 
     po::options_description audit("Audit");
     audit.add_options()
+                (AUDIT_ENABLED.c_str(),
+                        po::value<bool>()->default_value(false),
+                        "enable audit module")
                 (AUDIT_MEM_SIZE.c_str(),
                         po::value<size_t>()->default_value(10000),
                         "max size of audit datastructures")

--- a/options/simple_options.hpp
+++ b/options/simple_options.hpp
@@ -20,6 +20,7 @@
 namespace bzn::option_names
 {
     const std::string AUDIT_MEM_SIZE = "audit_mem_size";
+    const std::string AUDIT_ENABLED = "audit_enabled";
     const std::string BOOTSTRAP_PEERS_FILE = "bootstrap_file";
     const std::string BOOTSTRAP_PEERS_URL = "bootstrap_url";
     const std::string DEBUG_LOGGING = "debug_logging";

--- a/raft/raft.cpp
+++ b/raft/raft.cpp
@@ -1227,3 +1227,9 @@ raft::shutdown_on_exceeded_max_storage(bool do_throw)
         do_throw ? throw std::runtime_error(MSG_ERROR_MAXIMUM_STORAGE_EXCEEDED) : raise(SIGINT);
     }
 }
+
+void
+raft::set_audit_enabled(bool val)
+{
+    this->enable_audit = val;
+}

--- a/raft/raft.hpp
+++ b/raft/raft.hpp
@@ -80,6 +80,8 @@ namespace bzn
 
         bool get_peer_validation_enabled() override { return this->enable_peer_validation; };
 
+        void set_audit_enabled(bool val);
+
     private:
         friend class raft_log_base;
         friend class raft_log;


### PR DESCRIPTION
The issue is that a new daemon starting with a large state dir will
replay its entire history, sending an audit notification for each
message that's committed. For now, I'm just disabling audit by default.
In pbft, messages will not be replayed in this way so it won't be such a
concern.