### PR TITLE
KEP-497 Get Active Peer List for Given Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,59 @@ to the swarm leader:
 and the node will be removed from the peer list.
 ```
 
+#### Get the List of Peers from the Leader
+
+The active peers in the swarm can be obtained by sending a "get_peers" 
+WebSocket command to the leader. To perform this command create a JSON 
+command object and send it via wscat:
+
+    $ wscat -c http://<leader_address>:port
+    connected (press CTRL+C to quit)
+    >{"bzn-api" : "raft", "cmd" : "get_peers"}
+    >
+
+and the response will look like:
+
+    {
+        "message" :
+        [
+            {
+                "host" : "127.0.0.1",
+                "http_port" : 9082,
+                "name" : "peer0",
+                "port" : 49152,
+                "uuid" : "2e34a07f-fd6d-4575-927e-f83a9edd1866"
+            },
+            {
+                "host" : "127.0.0.1",
+                "http_port" : 9083,
+                "name" : "peer1",
+                "port" : 49153,
+                "uuid" : "a05809a3-0b77-4881-8fa7-b0e0e2ee9107"
+            }
+        ]
+    }
+
+If you send the request to a follower, the response will be:
+
+    {
+        "error" : "ERROR_GET_PEERS_MUST_BE_SENT_TO_LEADER",
+        "message" :
+        {
+            "leader" :
+            {
+                "host" : "127.0.0.1",
+                "http_port" : 9082,
+                "name" : "peer0",
+                "port" : 49152,
+                "uuid" : "2e34a07f-fd6d-4575-927e-f83a9edd1866"
+            }
+        }
+    }
+
+and you can resend the request to the leader.
+
+
 #### Help & Options
 
 ```text

--- a/raft/raft.cpp
+++ b/raft/raft.cpp
@@ -1257,20 +1257,6 @@ raft::to_peer_message(const peer_address_t& address)
     return bzn;
 }
 
-
-void
-raft::to_peer_message(const peer_address_t& address)
-{
-    bzn::message bzn;
-    bzn["port"] = address.port;
-    bzn["http_port"] = address.http_port;
-    bzn["host"] = address.host;
-    bzn["uuid"] = address.uuid;
-    bzn["name"] = address.name;
-    return bzn;
-}
-
-
 void
 raft::handle_get_peers(std::shared_ptr<bzn::session_base> session)
 {

--- a/raft/raft.cpp
+++ b/raft/raft.cpp
@@ -555,7 +555,7 @@ raft::handle_ws_raft_messages(const bzn::message& msg, std::shared_ptr<bzn::sess
         this->handle_add_peer(session, msg["data"]["peer"]);
         return;
     }
-    else if (msg["cmd"].asString() == "remove_peer" )
+    else if (msg["cmd"].asString() == "remove_peer")
     {
         if (!msg.isMember("data") || !msg["data"].isMember("uuid") || msg["data"]["uuid"].asString().empty())
         {
@@ -564,6 +564,11 @@ raft::handle_ws_raft_messages(const bzn::message& msg, std::shared_ptr<bzn::sess
         }
 
         this->handle_remove_peer(session, msg["data"]["uuid"].asString());
+        return;
+    }
+    else if (msg["cmd"].asString() == "get_peers")
+    {
+        this->handle_get_peers(session);
         return;
     }
 
@@ -880,10 +885,8 @@ raft::update_raft_state(uint32_t term, bzn::raft_state state)
 
 
 bzn::peer_address_t
-raft::get_leader()
+raft::get_leader_unsafe()
 {
-    std::lock_guard<std::mutex> lock(this->raft_lock);
-
     for(auto& peer : this->get_all_peers())
     {
         if (peer.uuid == this->leader)
@@ -891,8 +894,15 @@ raft::get_leader()
             return peer;
         }
     }
-
     return bzn::peer_address_t("",0,0,"","");
+}
+
+
+bzn::peer_address_t
+raft::get_leader()
+{
+    std::lock_guard<std::mutex> lock(this->raft_lock);
+    return this->get_leader_unsafe();
 }
 
 
@@ -1228,6 +1238,8 @@ raft::shutdown_on_exceeded_max_storage(bool do_throw)
     }
 }
 
+
+bzn::message raft::to_peer_message(const peer_address_t& address)
 void
 raft::set_audit_enabled(bool val)
 {
@@ -1237,11 +1249,42 @@ raft::set_audit_enabled(bool val)
 void
 raft::handle_get_peers(std::shared_ptr<bzn::session_base>& session)
 {
+    bzn::message bzn;
+    bzn["port"] = address.port;
+    bzn["http_port"] = address.http_port;
+    bzn["host"] = address.host;
+    bzn["uuid"] = address.uuid;
+    bzn["name"] = address.name;
+    return bzn;
+}
 
-    if (this->current_state != bzn::raft_state::leader)
+
+void raft::handle_get_peers(std::shared_ptr<bzn::session_base> session)
+{
+    bzn::message msg;
+    msg["error"] = ERROR_GET_PEERS_SELECTED_NODE_IN_UNKNOWN_STATE;
+
+    if (this->current_state == bzn::raft_state::follower)
     {
-        LOG(warning) << "No longer the leader. Ignoring message from peer: " << msg["data"]["from"].asString();
-        return;
+        LOG(error) << ERROR_GET_PEERS_MUST_BE_SENT_TO_LEADER;
+        msg["error"] = ERROR_GET_PEERS_MUST_BE_SENT_TO_LEADER;
+        msg["message"]["leader"] = this->to_peer_message(this->get_leader_unsafe());
     }
 
+    if (this->current_state == bzn::raft_state::candidate)
+    {
+        LOG(error) << ERROR_GET_PEERS_ELECTION_IN_PROGRESS_TRY_LATER;
+        msg["error"] = ERROR_GET_PEERS_ELECTION_IN_PROGRESS_TRY_LATER;
+    }
+
+    if (this->current_state == bzn::raft_state::leader)
+    {
+        msg.removeMember("error");
+        for(const auto& peer : this->get_all_peers())
+        {
+            msg["message"].append(this->to_peer_message(peer));
+        }
+    }
+
+    session->send_message(std::make_shared<bzn::message>(msg), false);
 }

--- a/raft/raft.cpp
+++ b/raft/raft.cpp
@@ -1233,3 +1233,15 @@ raft::set_audit_enabled(bool val)
 {
     this->enable_audit = val;
 }
+
+void
+raft::handle_get_peers(std::shared_ptr<bzn::session_base>& session)
+{
+
+    if (this->current_state != bzn::raft_state::leader)
+    {
+        LOG(warning) << "No longer the leader. Ignoring message from peer: " << msg["data"]["from"].asString();
+        return;
+    }
+
+}

--- a/raft/raft.hpp
+++ b/raft/raft.hpp
@@ -136,6 +136,9 @@ namespace bzn
         void handle_add_peer(std::shared_ptr<bzn::session_base> session, const bzn::message& peer);
         void handle_remove_peer(std::shared_ptr<bzn::session_base> session, const std::string& uuid);
 
+        void handle_get_peers(std::shared_ptr<bzn::session_base>& session);
+
+
         // helpers...
         void get_raft_timeout_scale();
 
@@ -154,7 +157,6 @@ namespace bzn
 
         bool is_majority(const std::set<bzn::uuid_t>& votes);
         uint32_t last_majority_replicated_log_index();
-        std::list<std::set<bzn::uuid_t>> get_active_quorum();
         bool in_quorum(const bzn::uuid_t& uuid);
         bzn::peers_list_t get_all_peers();
 


### PR DESCRIPTION
Implemented the web socket command get_peers. Send a get peers command:

{"cmd": "get_peers", "bzn-api": "raft"}

via wscat to the leader and you will get 

{
	"message" :
	[
		{
			"host" : "127.0.0.1",
			"http_port" : 9082,
			"name" : "peer0",
			"port" : 49152,
			"uuid" : "7b49e6e8-0408-459c-bb97-0036ca695363"
		},
		{
			"host" : "127.0.0.1",
			"http_port" : 9083,
			"name" : "peer1",
			"port" : 49153,
			"uuid" : "b5dde374-90f3-46d3-8f20-e9815f7a5ae0"
		}
	]
}

to a follower, you'll get:
{
	"error" : "ERROR_GET_PEERS_MUST_BE_SENT_TO_LEADER",
	"message" :
	{
		"leader" :
		{
			"host" : "127.0.0.1",
			"http_port" : 9082,
			"name" : "peer0",
			"port" : 49152,
			"uuid" : "7b49e6e8-0408-459c-bb97-0036ca695363"
		}
	}
}

Sending it to a candidate will get you a message telling you that an election is in progress, try later..