### PR TITLE
KEP-574 pbft - configurations

### DIFF
--- a/pbft/CMakeLists.txt
+++ b/pbft/CMakeLists.txt
@@ -6,13 +6,16 @@ add_library(pbft STATIC
         pbft_operation.hpp
         pbft_operation.cpp
 
+        pbft_configuration.hpp
+        pbft_configuration.cpp
+
         dummy_pbft_service.cpp
         dummy_pbft_service.hpp
         pbft_service_base.hpp
 
         pbft_failure_detector.cpp
         pbft_failure_detector.hpp
-        pbft_failure_detector_base.hpp)
+        pbft_failure_detector_base.hpp pbft_configuration.hpp pbft_configuration.cpp test/pbft_configuration_test.cpp pbft_config_store.hpp pbft_config_store.cpp test/pbft_config_store_test.cpp)
 
 target_link_libraries(pbft utils proto)
 target_include_directories(pbft PRIVATE ${JSONCPP_INCLUDE_DIRS} ${PROTO_INCLUDE_DIR})

--- a/pbft/pbft.cpp
+++ b/pbft/pbft.cpp
@@ -726,7 +726,7 @@ pbft::initialize_configuration(const bzn::peers_list_t& peers)
 {
     auto config = std::make_shared<pbft_configuration>();
     bool config_good = true;
-    for (auto p : peers)
+    for (auto& p : peers)
     {
         config_good &= config->add_peer(p);
     }
@@ -748,7 +748,9 @@ pbft::current_peers_ptr() const
 {
     auto config = this->configurations.current();
     if (config)
+    {
         return config->get_peers();
+    }
 
     throw std::runtime_error("No current configuration!");
 }

--- a/pbft/pbft.cpp
+++ b/pbft/pbft.cpp
@@ -46,26 +46,7 @@ pbft::pbft(
         throw std::runtime_error("No peers found!");
     }
 
-    // We cannot directly sort the peers list or a copy of it because peer addresses have const members
-    std::vector<peer_address_t> unordered_peers_list;
-    std::copy(peers.begin(), peers.end(), std::back_inserter(unordered_peers_list));
-
-    std::vector<size_t> indicies(peers.size());
-    std::iota(indicies.begin(), indicies.end(), 0);
-
-    std::sort(indicies.begin(), indicies.end(),
-        [&unordered_peers_list](const auto& i1, const auto& i2)
-        {
-            return unordered_peers_list[i1].uuid < unordered_peers_list[i2].uuid;
-        }
-    );
-
-    std::transform(indicies.begin(), indicies.end(), std::back_inserter(this->peer_index),
-        [&unordered_peers_list](auto& peer_index)
-        {
-            return unordered_peers_list[peer_index];
-        }
-    );
+    this->initialize_configuration(peers);
 
     // TODO: stable checkpoint should be read from disk first: KEP-494
     this->low_water_mark = this->stable_checkpoint.first;
@@ -313,7 +294,7 @@ pbft::broadcast(const bzn::encoded_message& msg)
 {
     auto msg_ptr = std::make_shared<bzn::encoded_message>(msg);
 
-    for (const auto& peer : this->peer_index)
+    for (const auto& peer : this->current_peers())
     {
         this->node->send_message_str(make_endpoint(peer), msg_ptr);
     }
@@ -411,7 +392,7 @@ pbft::is_primary() const
 const peer_address_t&
 pbft::get_primary() const
 {
-    return this->peer_index[this->view % this->peer_index.size()];
+    return this->current_peers()[this->view % this->current_peers().size()];
 }
 
 // Find this node's record of an operation (creating a new record for it if this is the first time we've heard of it)
@@ -439,7 +420,7 @@ pbft::find_operation(uint64_t view, uint64_t sequence, const pbft_request& reque
                    << request.ShortDebugString();
 
         std::shared_ptr<pbft_operation> op = std::make_shared<pbft_operation>(view, sequence, request,
-                std::make_shared<std::vector<peer_address_t>>(this->peer_index));
+                this->current_peers_ptr());
         auto result = operations.emplace(std::piecewise_construct, std::forward_as_tuple(std::move(key)), std::forward_as_tuple(op));
 
         assert(result.second);
@@ -641,7 +622,7 @@ pbft::quorum_size() const
 size_t
 pbft::max_faulty_nodes() const
 {
-    return this->peer_index.size()/3;
+    return this->current_peers().size()/3;
 }
 
 void
@@ -726,7 +707,7 @@ pbft::get_status()
     status["view"] = this->view;
 
     status["peer_index"] = bzn::json_message();
-    for(const auto& p : this->peer_index)
+    for(const auto& p : this->current_peers())
     {
         bzn::json_message peer;
         peer["host"] = p.host;
@@ -740,3 +721,40 @@ pbft::get_status()
     return status;
 }
 
+bool
+pbft::initialize_configuration(const bzn::peers_list_t& peers)
+{
+    auto config = std::make_shared<pbft_configuration>();
+    bool config_good = true;
+    for (auto p : peers)
+    {
+        config_good &= config->add_peer(p);
+    }
+
+    if (!config_good)
+    {
+        LOG(warning) << "One or more peers could not be added to configuration";
+    }
+
+    this->configurations.add(config);
+    this->configurations.enable(config->get_hash());
+    this->configurations.set_current(config->get_hash());
+
+    return config_good;
+}
+
+std::shared_ptr<const std::vector<bzn::peer_address_t>>
+pbft::current_peers_ptr() const
+{
+    auto config = this->configurations.current();
+    if (config)
+        return config->get_peers();
+
+    throw std::runtime_error("No current configuration!");
+}
+
+const std::vector<bzn::peer_address_t>&
+pbft::current_peers() const
+{
+    return *(this->current_peers_ptr());
+}

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -19,6 +19,7 @@
 #include <pbft/pbft_base.hpp>
 #include <pbft/pbft_failure_detector.hpp>
 #include <pbft/pbft_service_base.hpp>
+#include <pbft/pbft_config_store.hpp>
 #include <status/status_provider_base.hpp>
 #include <crypto/crypto_base.hpp>
 #include <mutex>
@@ -123,6 +124,10 @@ namespace bzn
         void clear_checkpoint_messages_until(const checkpoint_t&);
         void clear_operations_until(const checkpoint_t&);
 
+        bool initialize_configuration(const bzn::peers_list_t& peers);
+        std::shared_ptr<const std::vector<bzn::peer_address_t>> current_peers_ptr() const;
+        const std::vector<bzn::peer_address_t>& current_peers() const;
+
         // Using 1 as first value here to distinguish from default value of 0 in protobuf
         uint64_t view = 1;
         uint64_t next_issued_sequence_number = 1;
@@ -131,8 +136,6 @@ namespace bzn
         uint64_t high_water_mark;
 
         std::shared_ptr<bzn::node_base> node;
-
-        std::vector<bzn::peer_address_t> peer_index;
 
         const bzn::uuid_t uuid;
         std::shared_ptr<pbft_service_base> service;
@@ -156,6 +159,7 @@ namespace bzn
 
         std::set<checkpoint_t> local_unstable_checkpoints;
         std::map<checkpoint_t, std::unordered_map<uuid_t, std::string>> unstable_checkpoint_proofs;
+        pbft_config_store configurations;
 
         std::shared_ptr<crypto_base> crypto;
     };

--- a/pbft/pbft_config_store.cpp
+++ b/pbft/pbft_config_store.cpp
@@ -21,7 +21,7 @@ pbft_config_store::add(pbft_configuration::shared_const_ptr config)
 {
     // TODO - should we be making a copy here instead?
     // currently the added config could be changed externally after being added
-    return (this->configs.insert(std::make_pair(this->next_index++, std::make_pair(config, false)))).second;
+    return (this->configs.insert(std::make_pair(this->next_index++, std::make_pair(std::move(config), false)))).second;
 }
 
 pbft_config_store::config_map::const_iterator

--- a/pbft/pbft_config_store.cpp
+++ b/pbft/pbft_config_store.cpp
@@ -1,0 +1,104 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#include <pbft/pbft_config_store.hpp>
+
+using namespace bzn;
+
+pbft_config_store::pbft_config_store()
+    : current_index(0), next_index(1)
+{
+}
+
+bool
+pbft_config_store::add(pbft_configuration::shared_const_ptr config)
+{
+    // TODO - should we be making a copy here instead?
+    // currently the added config could be changed externally after being added
+    return (this->configs.insert(std::make_pair(this->next_index++, std::make_pair(config, false)))).second;
+}
+
+pbft_config_store::config_map::const_iterator
+pbft_config_store::find_by_hash(hash_t hash) const
+{
+    auto config = std::find_if(this->configs.begin(), this->configs.end(),
+        [hash](auto c)
+        {
+            return c.second.first->get_hash() == hash;
+        });
+
+    return config;
+}
+
+bool
+pbft_config_store::set_current(const hash_t& hash)
+{
+    auto config = this->find_by_hash(hash);
+    if (config == this->configs.end())
+        return false;
+
+    this->current_index = config->first;
+    return true;
+}
+
+bool
+pbft_config_store::remove_prior_to(const hash_t& hash)
+{
+    auto config = this->find_by_hash(hash);
+    if (config == this->configs.end())
+        return false;
+
+    this->configs.erase(this->configs.begin(), config);
+    return true;
+}
+
+pbft_configuration::shared_const_ptr
+pbft_config_store::get(const hash_t& hash) const
+{
+    auto config = this->find_by_hash(hash);
+    return config != this->configs.end() ? config->second.first : nullptr;
+}
+
+bool
+pbft_config_store::enable(const hash_t& hash, bool val)
+{
+    // can't find_by_hash here because we need a non-const
+    auto config = std::find_if(this->configs.begin(), this->configs.end(),
+        [hash](auto c)
+        {
+            return c.second.first->get_hash() == hash;
+        });
+
+    if (config != this->configs.end())
+    {
+        config->second.second = val;
+        return true;
+    }
+
+    return false;
+}
+
+bool
+pbft_config_store::is_enabled(const hash_t& hash) const
+{
+    auto config = this->find_by_hash(hash);
+    return config != this->configs.end() ? config->second.second : false;
+}
+
+pbft_configuration::shared_const_ptr
+pbft_config_store::current() const
+{
+    auto it = this->configs.find(this->current_index);
+    return it != this->configs.end() ? it->second.first : nullptr;
+}

--- a/pbft/pbft_config_store.cpp
+++ b/pbft/pbft_config_store.cpp
@@ -16,11 +16,6 @@
 
 using namespace bzn;
 
-pbft_config_store::pbft_config_store()
-    : current_index(0), next_index(1)
-{
-}
-
 bool
 pbft_config_store::add(pbft_configuration::shared_const_ptr config)
 {
@@ -46,7 +41,9 @@ pbft_config_store::set_current(const hash_t& hash)
 {
     auto config = this->find_by_hash(hash);
     if (config == this->configs.end())
+    {
         return false;
+    }
 
     this->current_index = config->first;
     return true;
@@ -57,7 +54,9 @@ pbft_config_store::remove_prior_to(const hash_t& hash)
 {
     auto config = this->find_by_hash(hash);
     if (config == this->configs.end())
+    {
         return false;
+    }
 
     this->configs.erase(this->configs.begin(), config);
     return true;
@@ -75,7 +74,7 @@ pbft_config_store::enable(const hash_t& hash, bool val)
 {
     // can't find_by_hash here because we need a non-const
     auto config = std::find_if(this->configs.begin(), this->configs.end(),
-        [hash](auto c)
+        [hash](auto& c)
         {
             return c.second.first->get_hash() == hash;
         });

--- a/pbft/pbft_config_store.hpp
+++ b/pbft/pbft_config_store.hpp
@@ -24,8 +24,6 @@ namespace bzn
     class pbft_config_store
     {
     public:
-        pbft_config_store();
-
         bool add(pbft_configuration::shared_const_ptr config);
         bool remove_prior_to(const hash_t& hash);
         pbft_configuration::shared_const_ptr get(const hash_t& hash) const;
@@ -43,8 +41,8 @@ namespace bzn
 
         // a map from the config index to a pair of <config, is_config_enabled>
         config_map configs;
-        index_t current_index;
-        index_t next_index;
+        index_t current_index = 0;
+        index_t next_index = 1;
     };
 }
 

--- a/pbft/pbft_config_store.hpp
+++ b/pbft/pbft_config_store.hpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <pbft/pbft_configuration.hpp>
+#include <map>
+
+namespace bzn
+{
+    using hash_t = std::string;
+
+    class pbft_config_store
+    {
+    public:
+        pbft_config_store();
+
+        bool add(pbft_configuration::shared_const_ptr config);
+        bool remove_prior_to(const hash_t& hash);
+        pbft_configuration::shared_const_ptr get(const hash_t& hash) const;
+
+        bool set_current(const hash_t& hash);
+        pbft_configuration::shared_const_ptr current() const;
+
+        bool enable(const hash_t& hash, bool val = true);
+        bool is_enabled(const hash_t& hash) const;
+
+    private:
+        using index_t = uint64_t;
+        using config_map = std::map<index_t, std::pair<pbft_configuration::shared_const_ptr, bool>>;
+        config_map::const_iterator find_by_hash(hash_t hash) const;
+
+        // a map from the config index to a pair of <config, is_config_enabled>
+        config_map configs;
+        index_t current_index;
+        index_t next_index;
+    };
+}
+

--- a/pbft/pbft_configuration.cpp
+++ b/pbft/pbft_configuration.cpp
@@ -1,0 +1,214 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#include "pbft_configuration.hpp"
+#include <cstdint>
+#include <memory>
+#include <algorithm>
+#include <numeric>
+#include <iterator>
+#include <functional>
+
+using namespace bzn;
+
+pbft_configuration::pbft_configuration()
+{
+    this->sorted_peers = std::make_shared<std::vector<bzn::peer_address_t>>();
+}
+
+bool
+pbft_configuration::operator==(const pbft_configuration& other) const
+{
+    return this->get_hash() == other.get_hash();
+}
+
+bool
+pbft_configuration::operator!=(const pbft_configuration& other) const
+{
+    return !(this->operator==(other));
+}
+
+bool
+pbft_configuration::from_json(const bzn::json_message& json)
+{
+    if (!json.isMember("peers") || !json["peers"].isArray())
+    {
+        LOG(error) << "Invalid configuration: " << json.toStyledString().substr(0, MAX_MESSAGE_SIZE) << "...";
+        return false;
+    }
+
+    bool result = true;
+    this->peers.clear();
+    for (auto p : json["peers"])
+    {
+        bzn::peer_address_t peer(p["host"].asString(), static_cast<uint16_t>(p["port"].asUInt()),
+            static_cast<uint16_t>(p["http_port"].asUInt()), p["name"].asString(), p["uuid"].asString());
+
+        if (this->conflicting_peer_exists(peer) || !this->valid_peer(peer))
+        {
+            LOG(warning) << "Attempt to add conflicting or invalid peer: "
+                         << json.toStyledString().substr(0, MAX_MESSAGE_SIZE) << "...";
+            result = false;
+        }
+        else
+        {
+            this->peers.insert(peer);
+        }
+    }
+
+    this->cache_sorted_peers();
+    return result;
+}
+
+bzn::json_message
+pbft_configuration::to_json() const
+{
+    bzn::json_message json;
+    json["peers"] = bzn::json_message();
+    for(const auto& p : *(this->sorted_peers))
+    {
+        bzn::json_message peer;
+        peer["host"] = p.host;
+        peer["port"] = p.port;
+        peer["http_port"] = p.http_port;
+        peer["name"] = p.name;
+        peer["uuid"] = p.uuid;
+
+        json["peers"].append(peer);
+    }
+
+    return json;
+}
+
+hash_t
+pbft_configuration::create_hash() const
+{
+    // TODO: better hash function
+
+    auto json = this->to_json().toStyledString();
+    size_t h = std::hash<std::string>{}(json);
+    return std::to_string(h);
+}
+
+hash_t
+pbft_configuration::get_hash() const
+{
+    return cached_hash;
+}
+
+std::shared_ptr<const std::vector<bzn::peer_address_t>>
+pbft_configuration::get_peers() const
+{
+    return this->sorted_peers;
+}
+
+bool
+pbft_configuration::insert_peer(const bzn::peer_address_t& peer)
+{
+    if (this->conflicting_peer_exists(peer) || !this->valid_peer(peer))
+    {
+        return false;
+    }
+
+    this->peers.insert(peer);
+    return true;
+}
+
+bool
+pbft_configuration::add_peer(const bzn::peer_address_t& peer)
+{
+    if (!this->insert_peer(peer))
+    {
+        return false;
+    }
+
+    this->cache_sorted_peers();
+    return true;
+}
+
+bool
+pbft_configuration::remove_peer(const bzn::peer_address_t& peer)
+{
+    auto p = this->peers.find(peer);
+    if (p != this->peers.end())
+    {
+        this->peers.erase(p);
+        this->cache_sorted_peers();
+        return true;
+    }
+
+    return false;
+}
+
+void
+pbft_configuration::cache_sorted_peers()
+{
+    // peer_address_t contains const members so sorting requires some juggling.
+    // first copy peers into a vector so we can access them via an index
+    std::vector<peer_address_t> unordered_peers_list;
+    std::copy(this->peers.begin(), this->peers.end(), std::back_inserter(unordered_peers_list));
+
+    // now create a vector of indices from 1..n
+    std::vector<size_t> indicies(peers.size());
+    std::iota(indicies.begin(), indicies.end(), 0);
+
+    // now sort the indices based on the peer uuids in the vector
+    std::sort(indicies.begin(), indicies.end(),
+        [&unordered_peers_list](const auto& i1, const auto& i2)
+        {
+          return unordered_peers_list[i1].uuid < unordered_peers_list[i2].uuid;
+        }
+    );
+
+    // and finally get each peer sequentially by sorted index and add to the destination vector
+    auto sorted = std::make_shared<std::vector<bzn::peer_address_t>>();
+    std::transform(indicies.begin(), indicies.end(), std::back_inserter(*sorted),
+        [&unordered_peers_list](auto& peer_index)
+        {
+           return unordered_peers_list[peer_index];
+        }
+    );
+
+    this->sorted_peers = sorted;
+    this->cached_hash = this->create_hash();
+}
+
+bool
+pbft_configuration::conflicting_peer_exists(const bzn::peer_address_t &peer) const
+{
+    for (auto p : this->peers)
+    {
+        if (p.uuid == peer.uuid || p.name == peer.name)
+            return true;
+
+        if (p.host == peer.host)
+        {
+            if (p.port == peer.port || p.http_port == peer.http_port)
+                return true;
+        }
+    }
+
+    return false;
+}
+
+bool
+pbft_configuration::valid_peer(const bzn::peer_address_t &peer) const
+{
+    if (peer.name.empty() || peer.uuid.empty() || peer.host.empty() || !peer.port || !peer.http_port)
+        return false;
+
+    // TODO: validate host address?
+
+    return true;
+}

--- a/pbft/pbft_configuration.cpp
+++ b/pbft/pbft_configuration.cpp
@@ -50,7 +50,7 @@ pbft_configuration::from_json(const bzn::json_message& json)
 
     bool result = true;
     this->peers.clear();
-    for (auto p : json["peers"])
+    for (auto& p : json["peers"])
     {
         bzn::peer_address_t peer(p["host"].asString(), static_cast<uint16_t>(p["port"].asUInt()),
             static_cast<uint16_t>(p["http_port"].asUInt()), p["name"].asString(), p["uuid"].asString());
@@ -96,9 +96,7 @@ pbft_configuration::create_hash() const
 {
     // TODO: better hash function
 
-    auto json = this->to_json().toStyledString();
-    size_t h = std::hash<std::string>{}(json);
-    return std::to_string(h);
+    return std::to_string(std::hash<std::string>{}(this->to_json().toStyledString()));
 }
 
 hash_t
@@ -180,22 +178,26 @@ pbft_configuration::cache_sorted_peers()
         }
     );
 
-    this->sorted_peers = sorted;
+    this->sorted_peers = std::move(sorted);
     this->cached_hash = this->create_hash();
 }
 
 bool
 pbft_configuration::conflicting_peer_exists(const bzn::peer_address_t &peer) const
 {
-    for (auto p : this->peers)
+    for (auto& p : this->peers)
     {
         if (p.uuid == peer.uuid || p.name == peer.name)
+        {
             return true;
+        }
 
         if (p.host == peer.host)
         {
             if (p.port == peer.port || p.http_port == peer.http_port)
+            {
                 return true;
+            }
         }
     }
 
@@ -206,7 +208,9 @@ bool
 pbft_configuration::valid_peer(const bzn::peer_address_t &peer) const
 {
     if (peer.name.empty() || peer.uuid.empty() || peer.host.empty() || !peer.port || !peer.http_port)
+    {
         return false;
+    }
 
     // TODO: validate host address?
 

--- a/pbft/pbft_configuration.hpp
+++ b/pbft/pbft_configuration.hpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <include/bluzelle.hpp>
+#include <proto/bluzelle.pb.h>
+#include <pbft/pbft_base.hpp>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace bzn
+{
+    using hash_t = std::string;
+
+    class pbft_configuration
+    {
+    public:
+        using shared_const_ptr = std::shared_ptr<const pbft_configuration>;
+
+        pbft_configuration();
+        bool operator==(const pbft_configuration& other) const;
+        bool operator!=(const pbft_configuration& other) const;
+
+        // de-serialize from json - returns true for success
+        bool from_json(const bzn::json_message& json);
+
+        // serialize to json
+        bzn::json_message to_json() const;
+
+        // returns the hash of this configuration
+        hash_t get_hash() const;
+
+        // returns a sorted vector of peers
+        std::shared_ptr<const std::vector<bzn::peer_address_t>> get_peers() const;
+
+        // add a new peer - returns true if success, false if invalid or duplicate peer
+        bool add_peer(const bzn::peer_address_t& peer);
+
+        // removes an existing peer - returns true if found and removed
+        bool remove_peer(const bzn::peer_address_t& peer);
+
+    private:
+        void cache_sorted_peers();
+        bool conflicting_peer_exists(const bzn::peer_address_t &peer) const;
+        bool valid_peer(const bzn::peer_address_t &peer) const;
+        bool insert_peer(const bzn::peer_address_t& peer);
+        hash_t create_hash() const;
+
+        std::unordered_set<bzn::peer_address_t> peers;
+        std::shared_ptr<std::vector<bzn::peer_address_t>> sorted_peers;
+        hash_t cached_hash;
+    };
+}
+

--- a/pbft/test/CMakeLists.txt
+++ b/pbft/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(test_srcs pbft_test.cpp pbft_operation_test.cpp pbft_failure_detector_test.cpp pbft_audit_test.cpp pbft_test_common.cpp pbft_checkpoint_tests.cpp)
+set(test_srcs pbft_test.cpp pbft_operation_test.cpp pbft_failure_detector_test.cpp pbft_audit_test.cpp pbft_test_common.cpp pbft_checkpoint_tests.cpp pbft_configuration_test.cpp pbft_config_store_test.cpp)
 set(test_libs pbft ${Protobuf_LIBRARIES} bootstrap)
 
 add_gmock_test(pbft)

--- a/pbft/test/pbft_config_store_test.cpp
+++ b/pbft/test/pbft_config_store_test.cpp
@@ -1,0 +1,108 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+
+#include <gtest/gtest.h>
+#include <include/bluzelle.hpp>
+#include <pbft/pbft_config_store.hpp>
+
+using namespace ::testing;
+
+namespace {
+
+    const std::vector<bzn::peer_address_t> TEST_PEER_LIST{{"127.0.0.1", 8081, 8881, "name1", "uuid1"},
+                                                          {"127.0.0.1", 8082, 8882, "name2", "uuid2"},
+                                                          {"127.0.0.1", 8083, 8883, "name3", "uuid3"},
+                                                          {"127.0.0.1", 8084, 8884, "name4", "uuid4"}};
+
+
+    class pbft_config_store_test : public Test
+    {
+    public:
+        bzn::pbft_config_store store;
+    };
+
+    TEST_F(pbft_config_store_test, initially_empty)
+    {
+        EXPECT_EQ(this->store.current(), nullptr);
+    }
+
+    TEST_F(pbft_config_store_test, add_test)
+    {
+        auto config = std::make_shared<bzn::pbft_configuration>();
+        EXPECT_TRUE(this->store.add(config));
+
+        auto config2 = this->store.get(config->get_hash());
+        ASSERT_TRUE(config2 != nullptr);
+        EXPECT_TRUE(*config == *config2);
+    }
+
+    TEST_F(pbft_config_store_test, current_test)
+    {
+        auto config = std::make_shared<bzn::pbft_configuration>();
+        EXPECT_TRUE(this->store.add(config));
+        EXPECT_EQ(this->store.current(), nullptr);
+
+        auto config2 = std::make_shared<bzn::pbft_configuration>();
+        config2->add_peer(TEST_PEER_LIST[0]);
+        EXPECT_TRUE(this->store.add(config2));
+        EXPECT_EQ(this->store.current(), nullptr);
+
+        EXPECT_TRUE(this->store.set_current(config->get_hash()));
+        EXPECT_EQ(*(this->store.current()), *config);
+        EXPECT_NE(*(this->store.current()), *config2);
+
+        EXPECT_TRUE(this->store.set_current(config2->get_hash()));
+        EXPECT_EQ(*(this->store.current()), *config2);
+        EXPECT_NE(*(this->store.current()), *config);
+    }
+
+    TEST_F(pbft_config_store_test, enable_test)
+    {
+        auto config = std::make_shared<bzn::pbft_configuration>();
+        EXPECT_TRUE(this->store.add(config));
+        EXPECT_FALSE(this->store.is_enabled(config->get_hash()));
+
+        EXPECT_TRUE(this->store.enable(config->get_hash()));
+        EXPECT_TRUE(this->store.is_enabled(config->get_hash()));
+        EXPECT_TRUE(this->store.enable(config->get_hash(), false));
+        EXPECT_FALSE(this->store.is_enabled(config->get_hash()));
+    }
+
+    TEST_F(pbft_config_store_test, removal_test)
+    {
+        std::vector<bzn::hash_t> hashes;
+        for (auto const& p : TEST_PEER_LIST)
+        {
+            auto cfg = std::make_shared<bzn::pbft_configuration>();
+            cfg->add_peer(p);
+            hashes.push_back(cfg->get_hash());
+            this->store.add(cfg);
+        }
+
+        for (auto const& h : hashes)
+        {
+            EXPECT_NE(this->store.get(h), nullptr);
+        }
+
+        auto config = std::make_shared<bzn::pbft_configuration>();
+        EXPECT_TRUE(this->store.add(config));
+        EXPECT_TRUE(this->store.remove_prior_to(config->get_hash()));
+
+        // all other configs should be gone except the last one
+        for (auto const& h : hashes)
+        {
+            EXPECT_EQ(this->store.get(h), nullptr);
+        }
+        EXPECT_NE(this->store.get(config->get_hash()), nullptr);
+    }
+}

--- a/pbft/test/pbft_configuration_test.cpp
+++ b/pbft/test/pbft_configuration_test.cpp
@@ -1,0 +1,120 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+
+#include <gtest/gtest.h>
+#include <include/bluzelle.hpp>
+#include <pbft/pbft_configuration.hpp>
+
+using namespace ::testing;
+
+namespace
+{
+
+    const std::vector<bzn::peer_address_t> TEST_PEER_LIST{{"127.0.0.1", 8081, 8881, "name1", "uuid1"},
+                                                          {"127.0.0.1", 8082, 8882, "name2", "uuid2"},
+                                                          {"127.0.0.1", 8083, 8883, "name3", "uuid3"},
+                                                          {"127.0.0.1", 8084, 8884, "name4", "uuid4"}};
+
+
+    class pbft_configuration_test : public Test
+    {
+    public:
+        bzn::pbft_configuration cfg;
+    };
+
+
+    TEST_F(pbft_configuration_test, initially_empty)
+    {
+        EXPECT_EQ(this->cfg.get_peers()->size(), 0U);
+    }
+
+    TEST_F(pbft_configuration_test, single_add_succeeds)
+    {
+        EXPECT_TRUE(this->cfg.add_peer(TEST_PEER_LIST[0]));
+        EXPECT_EQ(this->cfg.get_peers()->size(), 1U);
+    }
+
+    TEST_F(pbft_configuration_test, remove_succeeds)
+    {
+        EXPECT_TRUE(this->cfg.add_peer(TEST_PEER_LIST[0]));
+        EXPECT_EQ(this->cfg.get_peers()->size(), 1U);
+        EXPECT_TRUE(this->cfg.remove_peer(TEST_PEER_LIST[0]));
+        EXPECT_EQ(this->cfg.get_peers()->size(), 0U);
+    }
+
+    TEST_F(pbft_configuration_test, duplicate_add_fails)
+    {
+        EXPECT_TRUE(this->cfg.add_peer(TEST_PEER_LIST[0]));
+        EXPECT_EQ(this->cfg.get_peers()->size(), 1U);
+        EXPECT_FALSE(this->cfg.add_peer(TEST_PEER_LIST[0]));
+        EXPECT_EQ(this->cfg.get_peers()->size(), 1U);
+    }
+
+    TEST_F(pbft_configuration_test, bad_remove_fails)
+    {
+        EXPECT_TRUE(this->cfg.add_peer(TEST_PEER_LIST[0]));
+        EXPECT_EQ(this->cfg.get_peers()->size(), 1U);
+        EXPECT_FALSE(this->cfg.remove_peer(TEST_PEER_LIST[1]));
+        EXPECT_EQ(this->cfg.get_peers()->size(), 1U);
+    }
+
+    void check_equal(const std::vector<bzn::peer_address_t> &p1, const std::vector<bzn::peer_address_t> &p2)
+    {
+        ASSERT_EQ(p1.size(), p2.size());
+        for (uint i = 0; i < p1.size(); i++)
+        {
+            EXPECT_EQ(p1[i], p2[i]);
+        }
+    }
+
+    TEST_F(pbft_configuration_test, sort_order)
+    {
+        // add the peers in reverse order (assumes TEST_PEER_LIST is sorted)
+        for (auto it = TEST_PEER_LIST.rbegin(); it != TEST_PEER_LIST.rend(); it++)
+        {
+            EXPECT_TRUE(this->cfg.add_peer(*it));
+        }
+
+        auto peers = this->cfg.get_peers();
+        check_equal(*peers, TEST_PEER_LIST);
+    }
+
+    TEST_F(pbft_configuration_test, to_from_json)
+    {
+        for (const auto &peer : TEST_PEER_LIST)
+        {
+            this->cfg.add_peer(peer);
+        }
+
+        bzn::json_message json = this->cfg.to_json();
+        bzn::pbft_configuration cfg2;
+        cfg2.from_json(json);
+        check_equal(*(cfg2.get_peers()), TEST_PEER_LIST);
+    }
+
+    TEST_F(pbft_configuration_test, reject_invalid_peer)
+    {
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("", 8081, 8881, "name1", "uuid1")));
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 0, 8881, "name1", "uuid1")));
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 0, "name1", "uuid1")));
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 8881, "", "uuid1")));
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 8881, "name1", "")));
+        EXPECT_TRUE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 8881, "name1", "uuid1")));
+
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8082, 8882, "name2", "uuid1")));
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8082, 8882, "name1", "uuid2")));
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8082, 8881, "name2", "uuid2")));
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 8882, "name2", "uuid2")));
+        EXPECT_TRUE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8082, 8882, "name2", "uuid2")));
+    }
+}


### PR DESCRIPTION
Code for storing PBFT peers in an abstract "configuration" that can be versioned and passed as a message. The configuration class stores an individual config. The config_store class stores multiple configurations in order of adding, accesses them by hash, supports setting a configuration "enabled" and selecting a current configuration, as well as purging old ones.

The main PBFT code was updated to store the initial peers list in configuration and access it from there.