### PR TITLE
KEP-652: refactoring to remove sender field in pbft_msg

### DIFF
--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -51,7 +51,7 @@ namespace bzn
 
         void start() override;
 
-        void handle_message(const pbft_msg& msg) override;
+        void handle_message(const pbft_msg& msg, const wrapped_bzn_msg& original_msg) override;
 
         size_t outstanding_operations_count() const;
 
@@ -88,10 +88,10 @@ namespace bzn
         bool preliminary_filter_msg(const pbft_msg& msg);
 
         void handle_request(const pbft_request& msg, const std::shared_ptr<session_base>& session = nullptr);
-        void handle_preprepare(const pbft_msg& msg);
-        void handle_prepare(const pbft_msg& msg);
-        void handle_commit(const pbft_msg& msg);
-        void handle_checkpoint(const pbft_msg& msg);
+        void handle_preprepare(const pbft_msg& msg, const wrapped_bzn_msg& original_msg);
+        void handle_prepare(const pbft_msg& msg, const wrapped_bzn_msg& original_msg);
+        void handle_commit(const pbft_msg& msg, const wrapped_bzn_msg& original_msg);
+        void handle_checkpoint(const pbft_msg& msg, const wrapped_bzn_msg& original_msg);
 
         void maybe_advance_operation_state(const std::shared_ptr<pbft_operation>& op);
         void do_preprepare(const std::shared_ptr<pbft_operation>& op);

--- a/pbft/pbft_base.hpp
+++ b/pbft/pbft_base.hpp
@@ -32,7 +32,7 @@ namespace bzn
     public:
         virtual void start() = 0;
 
-        virtual void handle_message(const pbft_msg& msg) = 0;
+        virtual void handle_message(const pbft_msg& msg, const wrapped_bzn_msg& original_msg) = 0;
 
         virtual bool is_primary() const = 0;
 

--- a/pbft/pbft_operation.cpp
+++ b/pbft/pbft_operation.cpp
@@ -27,7 +27,7 @@ pbft_operation::pbft_operation(uint64_t view, uint64_t sequence, pbft_request re
 }
 
 void
-pbft_operation::record_preprepare()
+pbft_operation::record_preprepare(const wrapped_bzn_msg& /*encoded_preprepare*/)
 {
     this->preprepare_seen = true;
 }
@@ -39,9 +39,10 @@ pbft_operation::has_preprepare()
 }
 
 void
-pbft_operation::record_prepare(const pbft_msg& prepare)
+pbft_operation::record_prepare(const wrapped_bzn_msg& encoded_prepare)
 {
-    this->prepares_seen.insert(prepare.sender());
+    // TODO: Save message
+    this->prepares_seen.insert(encoded_prepare.sender());
 }
 
 size_t
@@ -57,9 +58,9 @@ pbft_operation::is_prepared()
 }
 
 void
-pbft_operation::record_commit(const pbft_msg& commit)
+pbft_operation::record_commit(const wrapped_bzn_msg& encoded_commit)
 {
-    this->commits_seen.insert(commit.sender());
+    this->commits_seen.insert(encoded_commit.sender());
 }
 
 bool

--- a/pbft/pbft_operation.hpp
+++ b/pbft/pbft_operation.hpp
@@ -50,13 +50,13 @@ namespace bzn
         operation_key_t get_operation_key();
         pbft_operation_state get_state();
 
-        void record_preprepare();
+        void record_preprepare(const wrapped_bzn_msg& encoded_preprepare);
         bool has_preprepare();
 
-        void record_prepare(const pbft_msg& prepare);
+        void record_prepare(const wrapped_bzn_msg& encoded_prepare);
         bool is_prepared();
 
-        void record_commit(const pbft_msg& commit);
+        void record_commit(const wrapped_bzn_msg& encoded_commit);
         bool is_committed();
 
         void begin_commit_phase();

--- a/pbft/test/pbft_audit_test.cpp
+++ b/pbft/test/pbft_audit_test.cpp
@@ -25,20 +25,23 @@ namespace bzn::test
         this->build_pbft();
         this->pbft->set_audit_enabled(true);
 
+        wrapped_bzn_msg dummy_original_msg;
         pbft_msg preprepare = pbft_msg(this->preprepare_msg);
         preprepare.set_sequence(1);
-        this->pbft->handle_message(preprepare);
+        this->pbft->handle_message(preprepare, dummy_original_msg);
 
         for (const auto& peer : TEST_PEER_LIST)
         {
             pbft_msg prepare = pbft_msg(preprepare);
+            wrapped_bzn_msg prepare_wrap;
             pbft_msg commit = pbft_msg(preprepare);
+            wrapped_bzn_msg commit_wrap;
             prepare.set_type(PBFT_MSG_PREPARE);
-            prepare.set_sender(peer.uuid);
+            prepare_wrap.set_sender(peer.uuid);
             commit.set_type(PBFT_MSG_COMMIT);
-            commit.set_sender(peer.uuid);
-            this->pbft->handle_message(prepare);
-            this->pbft->handle_message(commit);
+            commit_wrap.set_sender(peer.uuid);
+            this->pbft->handle_message(prepare, prepare_wrap);
+            this->pbft->handle_message(commit, commit_wrap);
         }
     }
 

--- a/pbft/test/pbft_checkpoint_tests.cpp
+++ b/pbft/test/pbft_checkpoint_tests.cpp
@@ -59,8 +59,7 @@ namespace bzn::test
         for (const auto& peer : TEST_PEER_LIST)
         {
             pbft_msg msg = cp1_msg;
-            msg.set_sender(peer.uuid);
-            this->pbft->handle_message(msg);
+            this->pbft->handle_message(msg, from(peer.uuid));
         }
 
         EXPECT_EQ(0u, this->pbft->latest_checkpoint().first);
@@ -84,8 +83,7 @@ namespace bzn::test
         for (const auto& peer : TEST_PEER_LIST)
         {
             pbft_msg msg = cp1_msg;
-            msg.set_sender(peer.uuid);
-            this->pbft->handle_message(msg);
+            this->pbft->handle_message(msg, from(peer.uuid));
         }
 
         EXPECT_EQ(CHECKPOINT_INTERVAL, this->pbft->latest_checkpoint().first);
@@ -99,8 +97,7 @@ namespace bzn::test
         for (const auto& peer : TEST_PEER_LIST)
         {
             pbft_msg msg = cp1_msg;
-            msg.set_sender(peer.uuid);
-            this->pbft->handle_message(msg);
+            this->pbft->handle_message(msg, from(peer.uuid));
         }
         this->service_execute_handler(request_msg.request(), CHECKPOINT_INTERVAL);
 
@@ -116,8 +113,7 @@ namespace bzn::test
         for (const auto& peer : TEST_PEER_LIST)
         {
             pbft_msg msg = cp1_msg;
-            msg.set_sender(peer.uuid);
-            this->pbft->handle_message(msg);
+            this->pbft->handle_message(msg, from(peer.uuid));
         }
         this->service_execute_handler(request_msg.request(), CHECKPOINT_INTERVAL*2);
 
@@ -133,17 +129,15 @@ namespace bzn::test
         for (const auto& peer : TEST_PEER_LIST)
         {
             pbft_msg msg = cp1_msg;
-            msg.set_sender(peer.uuid);
-            this->pbft->handle_message(msg);
+            this->pbft->handle_message(msg, from(peer.uuid));
         }
         this->service_execute_handler(request_msg.request(), CHECKPOINT_INTERVAL*2);
         for (const auto& peer : TEST_PEER_LIST)
         {
             pbft_msg msg = cp1_msg;
-            msg.set_sender(peer.uuid);
             msg.set_sequence(CHECKPOINT_INTERVAL*2);
             msg.set_state_hash(cp2_hash);
-            this->pbft->handle_message(msg);
+            this->pbft->handle_message(msg, from(peer.uuid));
         }
 
         EXPECT_EQ(CHECKPOINT_INTERVAL*2, this->pbft->latest_stable_checkpoint().first);
@@ -162,7 +156,7 @@ namespace bzn::test
             msg.set_sequence(i);
             msg.set_allocated_request(new pbft_request(this->request_msg.request()));
 
-            this->pbft->handle_message(msg);
+            this->pbft->handle_message(msg, default_original_msg);
         }
 
         EXPECT_EQ(9u, this->pbft->outstanding_operations_count());
@@ -171,8 +165,7 @@ namespace bzn::test
         for (const auto& peer : TEST_PEER_LIST)
         {
             pbft_msg msg = cp1_msg;
-            msg.set_sender(peer.uuid);
-            this->pbft->handle_message(msg);
+            this->pbft->handle_message(msg, from(peer.uuid));
         }
 
         EXPECT_EQ(0u, this->pbft->outstanding_operations_count());
@@ -202,8 +195,7 @@ namespace bzn::test
         for (const auto& peer : TEST_PEER_LIST)
         {
             pbft_msg msg = cp1_msg;
-            msg.set_sender(peer.uuid);
-            this->pbft->handle_message(msg);
+            this->pbft->handle_message(msg, from(peer.uuid));
         }
 
         EXPECT_EQ(CHECKPOINT_INTERVAL, this->pbft->latest_checkpoint().first);

--- a/pbft/test/pbft_operation_test.cpp
+++ b/pbft/test/pbft_operation_test.cpp
@@ -45,6 +45,8 @@ namespace
 
         bzn::pbft_operation op;
 
+        wrapped_bzn_msg empty_original_msg;
+
         pbft_operation_test()
                 : op(view, sequence, request, std::make_shared<std::vector<bzn::peer_address_t>>(TEST_PEER_LIST))
         {
@@ -60,11 +62,12 @@ namespace
 
     TEST_F(pbft_operation_test, prepared_after_all_msgs)
     {
-        this->op.record_preprepare();
+        wrapped_bzn_msg preprepare;
+        this->op.record_preprepare(preprepare);
 
         for (const auto& peer : TEST_PEER_LIST)
         {
-            pbft_msg msg;
+            wrapped_bzn_msg msg;
             msg.set_sender(peer.uuid);
             op.record_prepare(msg);
         }
@@ -77,7 +80,7 @@ namespace
     {
         for (const auto& peer : TEST_PEER_LIST)
         {
-            pbft_msg msg;
+            wrapped_bzn_msg msg;
             msg.set_sender(peer.uuid);
             op.record_prepare(msg);
         }
@@ -88,11 +91,12 @@ namespace
 
     TEST_F(pbft_operation_test, not_prepared_with_2f)
     {
-        this->op.record_preprepare();
+        wrapped_bzn_msg preprepare;
+        this->op.record_preprepare(preprepare);
 
         for (const auto& peer : TEST_2F_PEER_LIST)
         {
-            pbft_msg msg;
+            wrapped_bzn_msg msg;
             msg.set_sender(peer.uuid);
             op.record_prepare(msg);
         }
@@ -103,11 +107,12 @@ namespace
 
     TEST_F(pbft_operation_test, prepared_with_2f_PLUS_1)
     {
-        this->op.record_preprepare();
+        wrapped_bzn_msg preprepare;
+        this->op.record_preprepare(preprepare);
 
         for (const auto& peer : TEST_2F_PLUS_1_PEER_LIST)
         {
-            pbft_msg msg;
+            wrapped_bzn_msg msg;
             msg.set_sender(peer.uuid);
             op.record_prepare(msg);
         }

--- a/pbft/test/pbft_test_common.cpp
+++ b/pbft/test/pbft_test_common.cpp
@@ -115,6 +115,14 @@ namespace bzn::test
         return result;
     }
 
+    std::string
+    extract_sender(std::string msg)
+    {
+        wrapped_bzn_msg outer;
+        outer.ParseFromString(msg);
+        return outer.sender();
+    }
+
     wrapped_bzn_msg
     wrap_pbft_msg(const pbft_msg& msg)
     {
@@ -154,7 +162,7 @@ namespace bzn::test
     {
         pbft_msg msg = extract_pbft_msg(*wrapped_msg);
 
-        return msg.type() == PBFT_MSG_CHECKPOINT && msg.sequence() > 0 && msg.sender() != "" && msg.state_hash() != "";
+        return msg.type() == PBFT_MSG_CHECKPOINT && msg.sequence() > 0 && extract_sender(*wrapped_msg) != "" && msg.state_hash() != "";
     }
 
     bool
@@ -169,5 +177,13 @@ namespace bzn::test
         }
 
         return json["bzn-api"] == "audit";
+    }
+
+    wrapped_bzn_msg
+    from(uuid_t uuid)
+    {
+        wrapped_bzn_msg result;
+        result.set_sender(uuid);
+        return result;
     }
 }

--- a/pbft/test/pbft_test_common.hpp
+++ b/pbft/test/pbft_test_common.hpp
@@ -46,6 +46,7 @@ namespace bzn::test
     public:
         pbft_msg request_msg;
         pbft_msg preprepare_msg;
+        wrapped_bzn_msg default_original_msg;
 
         std::shared_ptr<bzn::asio::Mockio_context_base> mock_io_context =
                 std::make_shared<NiceMock<bzn::asio::Mockio_context_base >>();
@@ -79,6 +80,7 @@ namespace bzn::test
 
 
     pbft_msg extract_pbft_msg(std::string msg);
+    uuid_t extract_sender(std::string msg);
     wrapped_bzn_msg
     wrap_pbft_msg(const pbft_msg& msg);
     bool is_preprepare(std::shared_ptr<std::string> msg);
@@ -86,4 +88,6 @@ namespace bzn::test
     bool is_commit(std::shared_ptr<std::string> msg);
     bool is_checkpoint(std::shared_ptr<std::string> msg);
     bool is_audit(std::shared_ptr<std::string> msg);
+
+    wrapped_bzn_msg from(uuid_t uuid);
 }

--- a/proto/pbft.proto
+++ b/proto/pbft.proto
@@ -29,10 +29,6 @@ message pbft_msg
     // TODO: Most messages should contain only the hash of the request - KEP-344
     pbft_request request = 4;
 
-    // Needed for prepare, commit, request, checkpoing, but included always for clarity. This is the sender's uuid.
-    // TODO: remove
-    string sender = 5;
-
     // for checkpoints
     string state_hash = 6;
 }


### PR DESCRIPTION
The new structure is that pbft handlers take references to both the pbft_msg and the original wrapped_bzn_msg that contained it. The reason is that they need to do stuff based on the data contained in the message, but they also potentially need to store the original signed message for later forwarding. If they re-serialized their serialized copy, they could break the signature because serialization in protobuf is not guaranteed to be deterministic. 