### PR TITLE
KEP-613: New node gets caught up from old nodes

### DIFF
--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -97,6 +97,8 @@ namespace bzn
         void handle_commit(const pbft_msg& msg, const bzn_envelope& original_msg);
         void handle_checkpoint(const pbft_msg& msg, const bzn_envelope& original_msg);
         void handle_join_or_leave(const pbft_membership_msg& msg);
+        void handle_get_state(const pbft_membership_msg& msg, std::shared_ptr<bzn::session_base> session) const;
+        void handle_set_state(const pbft_membership_msg& msg);
         void handle_config_message(const pbft_msg& msg, const std::shared_ptr<pbft_operation>& op);
 
         void maybe_advance_operation_state(const std::shared_ptr<pbft_operation>& op);
@@ -108,6 +110,7 @@ namespace bzn
         void handle_bzn_message(const bzn_envelope& msg, std::shared_ptr<bzn::session_base> session);
         void handle_membership_message(const bzn_envelope& msg, std::shared_ptr<bzn::session_base> session = nullptr);
         bzn::encoded_message wrap_message(const pbft_msg& message, const std::string& debug_info = "");
+        bzn::encoded_message wrap_message(const pbft_membership_msg& message, const std::string& debug_info = "") const;
         bzn::encoded_message wrap_message(const audit_message& message, const std::string& debug_info = "");
         
         pbft_msg common_message_setup(const std::shared_ptr<pbft_operation>& op, pbft_msg_type type);
@@ -122,9 +125,13 @@ namespace bzn
 
         void checkpoint_reached_locally(uint64_t sequence);
         void maybe_stabilize_checkpoint(const checkpoint_t& cp);
+        void stabilize_checkpoint(const checkpoint_t& cp);
+        void request_checkpoint_state(const checkpoint_t& cp) const;
+        std::string get_checkpoint_state(const checkpoint_t& cp) const;
+        void set_checkpoint_state(const checkpoint_t& cp, const std::string& data);
 
         inline size_t quorum_size() const;
-        inline size_t max_faulty_nodes() const;
+        size_t max_faulty_nodes() const;
 
         void clear_local_checkpoints_until(const checkpoint_t&);
         void clear_checkpoint_messages_until(const checkpoint_t&);
@@ -180,6 +187,8 @@ namespace bzn
         FRIEND_TEST(pbft_test, test_new_config_prepare_handling);
         FRIEND_TEST(pbft_test, test_new_config_commit_handling);
         FRIEND_TEST(pbft_test, test_move_to_new_config);
+
+        friend class pbft_proto_test;
 
         std::shared_ptr<crypto_base> crypto;
     };

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -126,7 +126,8 @@ namespace bzn
         void checkpoint_reached_locally(uint64_t sequence);
         void maybe_stabilize_checkpoint(const checkpoint_t& cp);
         void stabilize_checkpoint(const checkpoint_t& cp);
-        void request_checkpoint_state(const checkpoint_t& cp) const;
+        const peer_address_t& select_peer_for_checkpoint(const checkpoint_t& cp);
+        void request_checkpoint_state(const checkpoint_t& cp);
         std::string get_checkpoint_state(const checkpoint_t& cp) const;
         void set_checkpoint_state(const checkpoint_t& cp, const std::string& data);
 
@@ -140,6 +141,7 @@ namespace bzn
         bool initialize_configuration(const bzn::peers_list_t& peers);
         std::shared_ptr<const std::vector<bzn::peer_address_t>> current_peers_ptr() const;
         const std::vector<bzn::peer_address_t>& current_peers() const;
+        const peer_address_t& get_peer_by_uuid(const std::string& uuid) const;
         void broadcast_new_configuration(pbft_configuration::shared_const_ptr config);
         bool is_configuration_acceptable_in_new_view(hash_t config_hash);
         bool move_to_new_configuration(hash_t config_hash);

--- a/pbft/test/CMakeLists.txt
+++ b/pbft/test/CMakeLists.txt
@@ -8,6 +8,8 @@ set(test_srcs
     pbft_configuration_test.cpp
     pbft_config_store_test.cpp
     pbft_join_leave_test.cpp
+    pbft_proto_test.cpp
+    pbft_catchup_test.cpp
     database_pbft_service_test.cpp)
 set(test_libs pbft crypto options ${Protobuf_LIBRARIES} bootstrap storage)
 

--- a/pbft/test/pbft_catchup_test.cpp
+++ b/pbft/test/pbft_catchup_test.cpp
@@ -1,0 +1,190 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+
+#include <pbft/test/pbft_test_common.hpp>
+#include <pbft/test/pbft_proto_test.hpp>
+#include <utils/make_endpoint.hpp>
+
+using namespace ::testing;
+
+namespace bzn
+{
+    namespace test
+    {
+        pbft_membership_msg
+        extract_pbft_membership_msg(const std::string& msg)
+        {
+            bzn_envelope outer;
+            outer.ParseFromString(msg);
+            pbft_membership_msg result;
+            result.ParseFromString(outer.pbft_membership());
+            return result;
+        }
+
+        bool
+        is_get_state(std::shared_ptr<std::string> wrapped_msg)
+        {
+            pbft_membership_msg msg = extract_pbft_membership_msg(*wrapped_msg);
+
+            return msg.type() == PBFT_MMSG_GET_STATE && msg.sequence() > 0 && !(extract_sender(*wrapped_msg).empty())
+                && !msg.state_hash().empty();
+        }
+
+        bool
+        is_set_state(std::shared_ptr<std::string> wrapped_msg)
+        {
+            pbft_membership_msg msg = extract_pbft_membership_msg(*wrapped_msg);
+
+            return msg.type() == PBFT_MMSG_SET_STATE && msg.sequence() > 0 && !(extract_sender(*wrapped_msg).empty())
+                   && msg.state_hash() != "";
+        }
+    }
+
+    using namespace test;
+
+    class pbft_catchup_test : public pbft_proto_test
+    {
+    public:
+
+        void send_get_state_request(uint64_t sequence)
+        {
+            pbft_membership_msg msg;
+            msg.set_type(PBFT_MMSG_GET_STATE);
+            msg.set_sequence(sequence);
+            msg.set_state_hash(std::to_string(sequence));
+            auto wmsg = wrap_pbft_membership_msg(msg);
+
+            this->membership_handler(wmsg, this->mock_session);
+        }
+    };
+
+    TEST_F(pbft_catchup_test, node_requests_state_after_unknown_checkpoint)
+    {
+        this->uuid = SECOND_NODE_UUID;
+        this->build_pbft();
+
+        // node shouldn't be sending any checkpoint messages right now
+        EXPECT_CALL(*mock_node, send_message_str(_, ResultOf(is_checkpoint, Eq(true))))
+            .Times((Exactly(0)));
+
+        auto nodes = TEST_PEER_LIST.begin();
+        size_t req_nodes = 2 * this->faulty_nodes_bound();
+        for (size_t i = 0; i < req_nodes; i++)
+        {
+            bzn::peer_address_t node(*nodes++);
+            send_checkpoint(node, 100);
+        }
+
+        // one more checkpoint message and the node should request state from primary
+        auto primary = this->pbft->get_primary();
+        EXPECT_CALL(*mock_node, send_message_str(make_endpoint(primary), ResultOf(is_get_state, Eq(true))))
+            .Times((Exactly(1)));
+
+        bzn::peer_address_t node(*nodes++);
+        send_checkpoint(node, 100);
+    }
+
+    TEST_F(pbft_catchup_test, node_doesnt_request_state_after_known_checkpoint)
+    {
+        this->uuid = SECOND_NODE_UUID;
+        this->build_pbft();
+
+        prepare_for_checkpoint(100);
+        for (size_t i = 0; i < 100; i++)
+        {
+            run_transaction_through_backup();
+        }
+
+        // since the node has this checkpoint it should NOT request state for it
+        EXPECT_CALL(*mock_node, send_message_str(_, ResultOf(is_get_state, Eq(true))))
+            .Times((Exactly(0)));
+        stabilize_checkpoint(100);
+    }
+
+    TEST_F(pbft_catchup_test, primary_provides_state)
+    {
+        this->build_pbft();
+
+        for (size_t i = 0; i < 99; i++)
+        {
+            run_transaction_through_primary();
+        }
+        prepare_for_checkpoint(100);
+        run_transaction_through_primary();
+        stabilize_checkpoint(100);
+
+        EXPECT_CALL(*mock_session, send_datagram(ResultOf(is_set_state, Eq(true))))
+            .Times((Exactly(1)));
+        send_get_state_request(100);
+    }
+
+    TEST_F(pbft_catchup_test, node_adopts_requested_checkpoint)
+    {
+        this->uuid = SECOND_NODE_UUID;
+        this->build_pbft();
+
+        // get the node to request state from primary
+        auto primary = this->pbft->get_primary();
+        EXPECT_CALL(*mock_node, send_message_str(make_endpoint(primary), ResultOf(is_get_state, Eq(true))))
+            .Times((Exactly(1)));
+
+        auto nodes = TEST_PEER_LIST.begin();
+        size_t req_nodes = 2 * this->faulty_nodes_bound() + 1;
+        for (size_t i = 0; i < req_nodes; i++)
+        {
+            bzn::peer_address_t node(*nodes++);
+            send_checkpoint(node, 100);
+        }
+
+        // send the node the checkpoint "data"
+        pbft_membership_msg reply;
+        reply.set_type(PBFT_MMSG_SET_STATE);
+        reply.set_sequence(100);
+        reply.set_state_hash("100");
+        reply.set_state_data("state_100");
+        auto wmsg = wrap_pbft_membership_msg(reply);
+        this->membership_handler(wmsg, nullptr);
+
+        EXPECT_EQ(this->pbft->latest_stable_checkpoint(), checkpoint_t(100, "100"));
+    }
+
+    TEST_F(pbft_catchup_test, node_doesnt_adopt_wrong_checkpoint)
+    {
+        this->uuid = SECOND_NODE_UUID;
+        this->build_pbft();
+
+        // get the node to request state from primary
+        auto primary = this->pbft->get_primary();
+        EXPECT_CALL(*mock_node, send_message_str(make_endpoint(primary), ResultOf(is_get_state, Eq(true))))
+            .Times((Exactly(1)));
+
+        auto nodes = TEST_PEER_LIST.begin();
+        size_t req_nodes = 2 * this->faulty_nodes_bound() + 1;
+        for (size_t i = 0; i < req_nodes; i++)
+        {
+            bzn::peer_address_t node(*nodes++);
+            send_checkpoint(node, 100);
+        }
+
+        // send the node the checkpoint "data"
+        pbft_membership_msg reply;
+        reply.set_type(PBFT_MMSG_SET_STATE);
+        reply.set_sequence(200);
+        reply.set_state_hash("200");
+        reply.set_state_data("state_200");
+        auto wmsg = wrap_pbft_membership_msg(reply);
+        this->membership_handler(wmsg, nullptr);
+
+        EXPECT_NE(this->pbft->latest_stable_checkpoint(), checkpoint_t(200, "200"));
+    }
+}

--- a/pbft/test/pbft_catchup_test.cpp
+++ b/pbft/test/pbft_catchup_test.cpp
@@ -85,9 +85,9 @@ namespace bzn
             send_checkpoint(node, 100);
         }
 
-        // one more checkpoint message and the node should request state from primary
+        // one more checkpoint message and the node should request state from a random node
         auto primary = this->pbft->get_primary();
-        EXPECT_CALL(*mock_node, send_message_str(make_endpoint(primary), ResultOf(is_get_state, Eq(true))))
+        EXPECT_CALL(*mock_node, send_message_str(_, ResultOf(is_get_state, Eq(true))))
             .Times((Exactly(1)));
 
         bzn::peer_address_t node(*nodes++);
@@ -133,9 +133,9 @@ namespace bzn
         this->uuid = SECOND_NODE_UUID;
         this->build_pbft();
 
-        // get the node to request state from primary
+        // get the node to request state
         auto primary = this->pbft->get_primary();
-        EXPECT_CALL(*mock_node, send_message_str(make_endpoint(primary), ResultOf(is_get_state, Eq(true))))
+        EXPECT_CALL(*mock_node, send_message_str(_, ResultOf(is_get_state, Eq(true))))
             .Times((Exactly(1)));
 
         auto nodes = TEST_PEER_LIST.begin();
@@ -163,9 +163,9 @@ namespace bzn
         this->uuid = SECOND_NODE_UUID;
         this->build_pbft();
 
-        // get the node to request state from primary
+        // get the node to request state
         auto primary = this->pbft->get_primary();
-        EXPECT_CALL(*mock_node, send_message_str(make_endpoint(primary), ResultOf(is_get_state, Eq(true))))
+        EXPECT_CALL(*mock_node, send_message_str(_, ResultOf(is_get_state, Eq(true))))
             .Times((Exactly(1)));
 
         auto nodes = TEST_PEER_LIST.begin();

--- a/pbft/test/pbft_join_leave_test.cpp
+++ b/pbft/test/pbft_join_leave_test.cpp
@@ -13,6 +13,7 @@
 
 #include <pbft/test/pbft_test_common.hpp>
 #include <utils/make_endpoint.hpp>
+#include <pbft/test/pbft_proto_test.hpp>
 
 using namespace ::testing;
 
@@ -136,14 +137,6 @@ namespace bzn
             auto wmsg = wrap_pbft_msg(commit);
             wmsg.set_sender(node.uuid);
             pbft->handle_message(commit, wmsg);
-        }
-
-        bzn_envelope
-        wrap_pbft_membership_msg(const pbft_membership_msg& msg)
-        {
-            bzn_envelope result;
-            result.set_pbft_membership(msg.SerializeAsString());
-            return result;
         }
     }
 

--- a/pbft/test/pbft_proto_test.cpp
+++ b/pbft/test/pbft_proto_test.cpp
@@ -1,0 +1,280 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+
+#include <pbft/test/pbft_test_common.hpp>
+#include <pbft/test/pbft_proto_test.hpp>
+
+using namespace ::testing;
+
+namespace bzn
+{
+    using namespace test;
+
+    size_t
+    pbft_proto_test::faulty_nodes_bound() const
+    {
+        return this->pbft->max_faulty_nodes();
+    }
+
+    std::shared_ptr<pbft_operation>
+    pbft_proto_test::send_request()
+    {
+        // after request is sent, SUT will send out pre-prepares to all nodes
+        auto operation = std::shared_ptr<pbft_operation>();
+        EXPECT_CALL(*this->mock_node, send_message_str(_, ResultOf(test::is_preprepare, Eq(true))))
+            .Times(Exactly(TEST_PEER_LIST.size()))
+            .WillRepeatedly(Invoke([&](auto, auto enc_bzn_msg)
+            {
+                bzn_envelope wmsg;
+                wmsg.ParseFromString(*enc_bzn_msg);
+
+                pbft_msg msg;
+                if (msg.ParseFromString(wmsg.pbft()))
+                {
+                    if (operation == nullptr)
+                    {
+                        operation = this->pbft->find_operation(this->view, msg.sequence(), msg.request());
+                    }
+
+                    // the SUT needs the pre-prepare it sends to itself in order to execute state machine
+                    this->send_preprepare(operation->sequence, operation->request);
+                }
+            }));
+
+        auto request = new pbft_request();
+        request->set_type(PBFT_REQ_DATABASE);
+        auto dmsg = new database_msg;
+        auto create = new database_create;
+        create->set_key(std::string("key_" + std::to_string(++this->index)));
+        create->set_value(std::string("value_" + std::to_string(this->index)));
+        dmsg->set_allocated_create(create);
+        request->set_allocated_operation(dmsg);
+
+        bzn::json_message empty_json_msg;
+        pbft->handle_request(*request, empty_json_msg);
+
+        return operation;
+    }
+
+    // send a preprepare message to SUT
+    void
+    pbft_proto_test::send_preprepare(uint64_t sequence, const pbft_request& request)
+    {
+        // after preprepare is sent, SUT will send out prepares to all nodes
+        EXPECT_CALL(*this->mock_node, send_message_str(_, ResultOf(test::is_prepare, Eq(true))))
+            .Times(Exactly(TEST_PEER_LIST.size()));
+
+        auto peer = *(TEST_PEER_LIST.begin());
+        pbft_msg preprepare;
+
+        preprepare.set_view(this->view);
+        preprepare.set_sequence(sequence);
+        preprepare.set_type(PBFT_MSG_PREPREPARE);
+        preprepare.set_allocated_request(new pbft_request(request));
+        auto wmsg = wrap_pbft_msg(preprepare);
+        wmsg.set_sender(peer.uuid);
+        pbft->handle_message(preprepare, wmsg);
+    }
+
+    // send fake prepares from all nodes to SUT
+    void
+    pbft_proto_test::send_prepares(uint64_t sequence, const pbft_request& request)
+    {
+        // after prepares are sent, SUT will send out commits to all nodes
+        EXPECT_CALL(*this->mock_node, send_message_str(_, ResultOf(test::is_commit, Eq(true))))
+            .Times(Exactly(TEST_PEER_LIST.size()));
+
+        for (const auto& peer : TEST_PEER_LIST)
+        {
+            pbft_msg prepare;
+
+            prepare.set_view(this->view);
+            prepare.set_sequence(sequence);
+            prepare.set_type(PBFT_MSG_PREPARE);
+            prepare.set_allocated_request(new pbft_request(request));
+            auto wmsg = wrap_pbft_msg(prepare);
+            wmsg.set_sender(peer.uuid);
+            pbft->handle_message(prepare, wmsg);
+        }
+    }
+
+    // send fake commits from all nodes to SUT
+    void
+    pbft_proto_test::send_commits(uint64_t sequence, const pbft_request& request)
+    {
+        // after commits are sent, SUT will post the operation for execution
+        // we want to simulate that it's been executed successfully
+        EXPECT_CALL(*(this->mock_io_context), post(_)).Times(Exactly(1));
+
+        for (const auto& peer : TEST_PEER_LIST)
+        {
+            pbft_msg commit;
+
+            commit.set_view(this->view);
+            commit.set_sequence(sequence);
+            commit.set_type(PBFT_MSG_COMMIT);
+            commit.set_allocated_request(new pbft_request(request));
+            auto wmsg = wrap_pbft_msg(commit);
+            wmsg.set_sender(peer.uuid);
+            pbft->handle_message(commit, wmsg);
+        }
+
+        // tell pbft that this operation has been executed
+        this->service_execute_handler(request, sequence);
+    }
+
+    void
+    pbft_proto_test::prepare_for_checkpoint(size_t seq)
+    {
+        // pbft needs a hash for this checkpoint
+        EXPECT_CALL(*this->mock_service, service_state_hash(seq)).Times(Exactly(1))
+            .WillRepeatedly(Invoke([&](auto s)
+            {
+                return std::to_string(s);
+            }));
+
+        // after enough commits are sent, SUT will send out checkpoint message to all nodes
+        EXPECT_CALL(*this->mock_node, send_message_str(_, ResultOf(test::is_checkpoint, Eq(true))))
+            .Times(Exactly(TEST_PEER_LIST.size()));
+    }
+
+    void
+    pbft_proto_test::force_checkpoint(size_t seq)
+    {
+        this->pbft->checkpoint_reached_locally(seq);
+    }
+
+    void
+    pbft_proto_test::send_checkpoint(bzn::peer_address_t node, uint64_t sequence)
+    {
+        pbft_msg cp;
+        cp.set_sequence(sequence);
+        cp.set_type(PBFT_MSG_CHECKPOINT);
+        cp.set_state_hash(std::to_string(sequence));
+
+        auto wmsg = wrap_pbft_msg(cp);
+        wmsg.set_sender(node.uuid);
+        this->pbft->handle_message(cp, wmsg);
+    }
+
+    void
+    pbft_proto_test::stabilize_checkpoint(size_t seq)
+    {
+        for (const auto& peer : TEST_PEER_LIST)
+        {
+            if (peer.uuid == this->uuid)
+            {
+                continue;
+            }
+
+            this->send_checkpoint(peer, seq);
+        }
+    }
+
+    void
+    pbft_proto_test::run_transaction_through_primary(bool commit)
+    {
+        // send request to SUT and handle expected calls
+        auto op = send_request();
+        ASSERT_NE(op, nullptr);
+
+        // send node prepares to SUT
+        send_prepares(op->sequence, op->request);
+
+        // send node commits to SUT
+        if (commit)
+        {
+            send_commits(op->sequence, op->request);
+        }
+    }
+
+    void
+    pbft_proto_test::run_transaction_through_backup(bool commit)
+    {
+        // create request
+        pbft_request request;
+        request.set_type(PBFT_REQ_DATABASE);
+        auto dmsg = new database_msg;
+        auto create = new database_create;
+        create->set_key(std::string("key_" + std::to_string(++this->index)));
+        create->set_value(std::string("value_" + std::to_string(this->index)));
+        dmsg->set_allocated_create(create);
+        request.set_allocated_operation(dmsg);
+
+        // send pre-prepare to SUT
+        send_preprepare(this->index, request);
+
+        // send prepares to SUT
+        send_prepares(this->index, request);
+
+        // send commits to SUT
+        if (commit)
+        {
+            send_commits(this->index, request);
+        }
+    }
+
+    TEST_F(pbft_proto_test, test_primary_full_checkpoint)
+    {
+        this->build_pbft();
+
+        for (size_t i = 0; i < 99; i++)
+        {
+            run_transaction_through_primary();
+        }
+        prepare_for_checkpoint(100);
+        run_transaction_through_primary();
+    }
+
+    TEST_F(pbft_proto_test, test_primary_quick_checkpoint)
+    {
+        this->build_pbft();
+
+        for (size_t i = 0; i < 9; i++)
+        {
+            run_transaction_through_primary();
+        }
+        prepare_for_checkpoint(10);
+        run_transaction_through_primary();
+        force_checkpoint(10);
+    }
+
+
+    TEST_F(pbft_proto_test, test_backup_full_checkpoint)
+    {
+        this->uuid = SECOND_NODE_UUID;
+        this->build_pbft();
+
+        for (size_t i = 0; i < 99; i++)
+        {
+            run_transaction_through_backup();
+        }
+        prepare_for_checkpoint(100);
+        run_transaction_through_backup();
+    }
+
+    TEST_F(pbft_proto_test, test_backup_quick_checkpoint)
+    {
+        this->uuid = SECOND_NODE_UUID;
+        this->build_pbft();
+
+        for (size_t i = 0; i < 9; i++)
+        {
+            run_transaction_through_backup();
+        }
+        prepare_for_checkpoint(10);
+        run_transaction_through_backup();
+        force_checkpoint(10);
+    }
+}
+

--- a/pbft/test/pbft_proto_test.cpp
+++ b/pbft/test/pbft_proto_test.cpp
@@ -43,11 +43,11 @@ namespace bzn
                 {
                     if (operation == nullptr)
                     {
-                        operation = this->pbft->find_operation(this->view, msg.sequence(), msg.request());
-                    }
+                        operation = this->pbft->find_operation(this->view, msg.sequence(), msg.request_hash());
 
-                    // the SUT needs the pre-prepare it sends to itself in order to execute state machine
-                    this->send_preprepare(operation->sequence, operation->request);
+                        // the SUT needs the pre-prepare it sends to itself in order to execute state machine
+                        this->send_preprepare(operation->sequence, operation->get_encoded_request());
+                    }
                 }
             }));
 
@@ -60,15 +60,19 @@ namespace bzn
         dmsg->set_allocated_create(create);
         request->set_allocated_operation(dmsg);
 
-        bzn::json_message empty_json_msg;
-        pbft->handle_request(*request, empty_json_msg);
+        bzn_msg wmsg;
+
+
+        bzn::json_message json_msg;
+        json_msg["msg"] = request->SerializeAsString();
+        pbft->handle_request(*request, json_msg);
 
         return operation;
     }
 
     // send a preprepare message to SUT
     void
-    pbft_proto_test::send_preprepare(uint64_t sequence, const pbft_request& request)
+    pbft_proto_test::send_preprepare(uint64_t sequence, const bzn::encoded_message& request)
     {
         // after preprepare is sent, SUT will send out prepares to all nodes
         EXPECT_CALL(*this->mock_node, send_message_str(_, ResultOf(test::is_prepare, Eq(true))))
@@ -80,7 +84,8 @@ namespace bzn
         preprepare.set_view(this->view);
         preprepare.set_sequence(sequence);
         preprepare.set_type(PBFT_MSG_PREPREPARE);
-        preprepare.set_allocated_request(new pbft_request(request));
+        preprepare.set_request(request);
+        preprepare.set_request_hash(this->pbft->crypto->hash(request));
         auto wmsg = wrap_pbft_msg(preprepare);
         wmsg.set_sender(peer.uuid);
         pbft->handle_message(preprepare, wmsg);
@@ -88,7 +93,7 @@ namespace bzn
 
     // send fake prepares from all nodes to SUT
     void
-    pbft_proto_test::send_prepares(uint64_t sequence, const pbft_request& request)
+    pbft_proto_test::send_prepares(uint64_t sequence, const bzn::hash_t& request_hash)
     {
         // after prepares are sent, SUT will send out commits to all nodes
         EXPECT_CALL(*this->mock_node, send_message_str(_, ResultOf(test::is_commit, Eq(true))))
@@ -101,7 +106,7 @@ namespace bzn
             prepare.set_view(this->view);
             prepare.set_sequence(sequence);
             prepare.set_type(PBFT_MSG_PREPARE);
-            prepare.set_allocated_request(new pbft_request(request));
+            prepare.set_request_hash(request_hash);
             auto wmsg = wrap_pbft_msg(prepare);
             wmsg.set_sender(peer.uuid);
             pbft->handle_message(prepare, wmsg);
@@ -110,7 +115,7 @@ namespace bzn
 
     // send fake commits from all nodes to SUT
     void
-    pbft_proto_test::send_commits(uint64_t sequence, const pbft_request& request)
+    pbft_proto_test::send_commits(uint64_t sequence, const bzn::hash_t& request_hash)
     {
         // after commits are sent, SUT will post the operation for execution
         // we want to simulate that it's been executed successfully
@@ -123,14 +128,14 @@ namespace bzn
             commit.set_view(this->view);
             commit.set_sequence(sequence);
             commit.set_type(PBFT_MSG_COMMIT);
-            commit.set_allocated_request(new pbft_request(request));
+            commit.set_request_hash(request_hash);
             auto wmsg = wrap_pbft_msg(commit);
             wmsg.set_sender(peer.uuid);
             pbft->handle_message(commit, wmsg);
         }
 
         // tell pbft that this operation has been executed
-        this->service_execute_handler(request, sequence);
+        this->service_execute_handler(this->pbft->find_operation(this->view, sequence, request_hash));
     }
 
     void
@@ -189,12 +194,12 @@ namespace bzn
         ASSERT_NE(op, nullptr);
 
         // send node prepares to SUT
-        send_prepares(op->sequence, op->request);
+        send_prepares(op->sequence, op->request_hash);
 
         // send node commits to SUT
         if (commit)
         {
-            send_commits(op->sequence, op->request);
+            send_commits(op->sequence, op->request_hash);
         }
     }
 
@@ -212,15 +217,16 @@ namespace bzn
         request.set_allocated_operation(dmsg);
 
         // send pre-prepare to SUT
-        send_preprepare(this->index, request);
+        send_preprepare(this->index, request.SerializeAsString());
 
         // send prepares to SUT
-        send_prepares(this->index, request);
+        auto request_hash = this->pbft->crypto->hash(request.SerializeAsString());
+        send_prepares(this->index, request_hash);
 
         // send commits to SUT
         if (commit)
         {
-            send_commits(this->index, request);
+            send_commits(this->index, request_hash);
         }
     }
 

--- a/pbft/test/pbft_proto_test.hpp
+++ b/pbft/test/pbft_proto_test.hpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+
+#include <pbft/test/pbft_test_common.hpp>
+
+using namespace ::testing;
+
+namespace bzn
+{
+    using namespace test;
+
+    class pbft_proto_test : public pbft_test
+    {
+    public:
+        // send a fake request to SUT
+        std::shared_ptr<pbft_operation> send_request();
+
+        // send a preprepare message to SUT
+        void send_preprepare(uint64_t sequence, const pbft_request& request);
+
+        // send fake prepares from all nodes to SUT
+        void send_prepares(uint64_t sequence, const pbft_request& request);
+
+        // send fake commits from all nodes to SUT
+        void send_commits(uint64_t sequence, const pbft_request& request);
+
+        // set expectations for upcoming checkpoint
+        void prepare_for_checkpoint(size_t seq);
+
+        // send a checkpoint message on behalf of a node
+        void send_checkpoint(bzn::peer_address_t node, uint64_t sequence);
+
+        // send checkpoints from all nodes
+        void stabilize_checkpoint(size_t seq);
+
+        // get SUT to create a checkpoint at a specific sequence number
+        void force_checkpoint(size_t seq);
+
+        // send a database request through a primary all the way to possibly committing it
+        void run_transaction_through_primary(bool commit = true);
+
+        // send a database request through a backup node all the way to possibly committing it
+        void run_transaction_through_backup(bool commit = true);
+
+        // return the number of nodes that represent "f"
+        size_t faulty_nodes_bound() const;
+
+        // current request sequence
+        size_t index = 0;
+
+        // current view
+        uint64_t view = 1;
+    };
+}
+

--- a/pbft/test/pbft_proto_test.hpp
+++ b/pbft/test/pbft_proto_test.hpp
@@ -26,13 +26,13 @@ namespace bzn
         std::shared_ptr<pbft_operation> send_request();
 
         // send a preprepare message to SUT
-        void send_preprepare(uint64_t sequence, const pbft_request& request);
+        void send_preprepare(uint64_t sequence, const bzn::encoded_message& request);
 
         // send fake prepares from all nodes to SUT
-        void send_prepares(uint64_t sequence, const pbft_request& request);
+        void send_prepares(uint64_t sequence, const bzn::hash_t& request_hash);
 
         // send fake commits from all nodes to SUT
-        void send_commits(uint64_t sequence, const pbft_request& request);
+        void send_commits(uint64_t sequence, const bzn::hash_t& request_hash);
 
         // set expectations for upcoming checkpoint
         void prepare_for_checkpoint(size_t seq);

--- a/pbft/test/pbft_test_common.cpp
+++ b/pbft/test/pbft_test_common.cpp
@@ -36,8 +36,9 @@ namespace bzn::test
             .Times(Exactly(1))
             .WillOnce(
                 Invoke(
-                    [&](const auto&, auto)
+                    [&](const auto&, auto handler)
                     {
+                        this->membership_handler = handler;
                         return true;
                     }
                 ));
@@ -141,6 +142,14 @@ namespace bzn::test
     {
         bzn_envelope result;
         result.set_pbft(msg.SerializeAsString());
+        return result;
+    }
+
+    bzn_envelope
+    wrap_pbft_membership_msg(const pbft_membership_msg& msg)
+    {
+        bzn_envelope result;
+        result.set_pbft_membership(msg.SerializeAsString());
         return result;
     }
 

--- a/pbft/test/pbft_test_common.hpp
+++ b/pbft/test/pbft_test_common.hpp
@@ -76,6 +76,7 @@ namespace bzn::test
         bzn::execute_handler_t service_execute_handler;
         bzn::protobuf_handler message_handler;
         bzn::message_handler database_handler;
+        bzn::protobuf_handler membership_handler;
 
         bzn::uuid_t uuid = TEST_NODE_UUID;
 
@@ -94,6 +95,8 @@ namespace bzn::test
 
     bzn_envelope
     wrap_pbft_msg(const pbft_msg& msg);
+
+    bzn_envelope wrap_pbft_membership_msg(const pbft_membership_msg& msg);
 
     bzn::json_message
     wrap_request(const database_msg& msg);

--- a/proto/database.proto
+++ b/proto/database.proto
@@ -35,6 +35,8 @@ message database_msg
 
         database_subscribe      subscribe = 9;
         database_unsubscribe    unsubscribe = 10;
+
+        database_nullmsg        nullmsg = 11;
     }
 }
 
@@ -151,3 +153,5 @@ message database_response
         database_error                  error = 8;
     }
 }
+
+message database_nullmsg {}

--- a/proto/pbft.proto
+++ b/proto/pbft.proto
@@ -75,6 +75,13 @@ message pbft_membership_msg
 
     // for join/leave requests
     pbft_peer_info peer_info = 2;
+
+    // for get_state, set_state
+    uint64 sequence = 3;
+    string state_hash = 4;
+
+    // for set_state
+    string state_data = 5;
 }
 
 enum pbft_membership_msg_type
@@ -82,6 +89,8 @@ enum pbft_membership_msg_type
     PBFT_MMSG_UNDEFINED = 0;
     PBFT_MMSG_JOIN = 1;
     PBFT_MMSG_LEAVE = 2;
+    PBFT_MMSG_GET_STATE = 3;
+    PBFT_MMSG_SET_STATE = 4;
 }
 
 message pbft_peer_info


### PR DESCRIPTION
Implementation of node state catchup. When a node sees a stable checkpoint that it doesn't have locally, it assumes it is behind and requests the database state at that point. When it receives the state it populates its database, which allows it to apply any pending operations after the checkpoint and get caught up.