### PR TITLE
KEP-809: Database requests no longer use json wrapper. Requests

### DIFF
--- a/crypto/crypto.cpp
+++ b/crypto/crypto.cpp
@@ -40,9 +40,13 @@ crypto::extract_payload(const bzn_envelope& msg)
 {
     switch (msg.payload_case())
     {
-        case bzn_envelope::kPbftRequest :
+        case bzn_envelope::kDatabaseMsg :
         {
-            return msg.pbft_request();
+            return msg.database_msg();
+        }
+        case bzn_envelope::kPbftInternalRequest :
+        {
+            return msg.pbft_internal_request();
         }
         case bzn_envelope::kDatabaseResponse :
         {
@@ -206,6 +210,15 @@ crypto::hash(const std::string& msg)
     }
 
     return std::string(reinterpret_cast<char*>(hash_buffer.get()), md_size);
+}
+
+std::string
+crypto::hash(const bzn_envelope& msg)
+{
+    // We are assuming that msg.sender() and msg.payload_case() have
+    // constant-ish length, which is probably true if the signature was checked
+    // on the way in
+    return this->hash(msg.sender() + std::to_string(msg.payload_case()) + this->extract_payload(msg));
 }
 
 void

--- a/crypto/crypto.hpp
+++ b/crypto/crypto.hpp
@@ -35,6 +35,8 @@ namespace bzn
 
         std::string hash(const std::string& msg) override;
 
+        std::string hash(const bzn_envelope& msg) override;
+
     private:
 
         using EC_KEY_ptr_t = std::unique_ptr<EC_KEY, decltype(&::EC_KEY_free)>;

--- a/crypto/crypto.hpp
+++ b/crypto/crypto.hpp
@@ -50,6 +50,8 @@ namespace bzn
 
         const std::string& extract_payload(const bzn_envelope& msg);
 
+        const std::string deterministic_serialize(const bzn_envelope& msg);
+
         std::shared_ptr<bzn::options_base> options;
 
         EVP_PKEY_ptr_t private_key_EVP = EVP_PKEY_ptr_t(nullptr, &EVP_PKEY_free);

--- a/crypto/crypto_base.hpp
+++ b/crypto/crypto_base.hpp
@@ -36,11 +36,17 @@ namespace bzn
         virtual bool verify(const bzn_envelope& msg) = 0;
 
         /*
-         * Compute the hash of some message
+         * Compute the hash of some string
          * @msg data
          * @return hash value
          */
         virtual std::string hash(const std::string& msg) = 0;
+
+        /*
+         * @msg data
+         * @return hash value
+         */
+        virtual std::string hash(const bzn_envelope& msg) = 0;
 
         virtual ~crypto_base() = default;
     };

--- a/mocks/mock_node_base.hpp
+++ b/mocks/mock_node_base.hpp
@@ -30,8 +30,10 @@ class Mocknode_base : public node_base {
       bool(const bzn_envelope::PayloadCase msg_type, bzn::protobuf_handler message_handler));
   MOCK_METHOD0(start,
       void());
-  MOCK_METHOD2(send_message,
+  MOCK_METHOD2(send_message_json,
       void(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::json_message> msg));
+  MOCK_METHOD2(send_message,
+      void(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn_envelope> msg));
   MOCK_METHOD2(send_message_str,
       void(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::encoded_message> msg));
 };

--- a/mocks/mock_pbft_service_base.hpp
+++ b/mocks/mock_pbft_service_base.hpp
@@ -25,7 +25,7 @@ namespace bzn {
       MOCK_METHOD1(apply_operation,
           void(std::shared_ptr<bzn::pbft_operation>));
       MOCK_CONST_METHOD2(query,
-          void(const pbft_request& request, uint64_t sequence_number));
+          void(const database_msg& request, uint64_t sequence_number));
       MOCK_CONST_METHOD1(service_state_hash,
           bzn::hash_t(uint64_t sequence_number));
       MOCK_METHOD1(consolidate_log,

--- a/node/node.cpp
+++ b/node/node.cpp
@@ -218,7 +218,7 @@ node::send_message_str(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr
 }
 
 void
-node::send_message(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::json_message> msg)
+node::send_message_json(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::json_message> msg)
 {
     this->send_message_str(ep, std::make_shared<bzn::encoded_message>(msg->toStyledString()));
 }

--- a/node/node.hpp
+++ b/node/node.hpp
@@ -40,9 +40,9 @@ namespace bzn
 
         void start() override;
 
-        void send_message(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::json_message> msg) override;
+        void send_message_json(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::json_message> msg) override;
 
-        void send_message(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn_envelope> msg);
+        void send_message(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn_envelope> msg) override;
 
         void send_message_str(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::encoded_message> msg) override;
 

--- a/node/node_base.hpp
+++ b/node/node_base.hpp
@@ -53,7 +53,15 @@ namespace bzn
          * @param ep            host to send the message to
          * @param msg           message to send
          */
-        virtual void send_message(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::json_message> msg) = 0;
+        virtual void send_message_json(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::json_message> msg) = 0;
+
+        /**
+         * Convenience method to connect and send a message to a node. Will appropriately populate the sender and
+         * signature fields, if not already set.
+         * @param ep            host to send the message to
+         * @param msg           message to send
+         */
+        virtual void send_message(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn_envelope> msg) = 0;
 
         /**
          * Convenience method to connect and send a message to a node. Will set sender and signature fields as appropriate.

--- a/node/test/node_test.cpp
+++ b/node/test/node_test.cpp
@@ -251,7 +251,7 @@ namespace  bzn
                 return std::move(mock_websocket_stream);
             }));
 
-        node->send_message(TEST_ENDPOINT, std::make_shared<bzn::json_message>("{}"));
+        node->send_message_json(TEST_ENDPOINT, std::make_shared<bzn::json_message>("{}"));
 
         // call with no error to validate handshake...
         connect_handler(boost::system::error_code());

--- a/pbft/pbft.cpp
+++ b/pbft/pbft.cpp
@@ -84,6 +84,7 @@ pbft::start()
                                             {
                                                 // TODO: Get real pbft_operation pointers from pbft_service
                                                 LOG(error) << "Ignoring null operation pointer recieved from pbft_service";
+                                                return;
                                             }
 
                                             fd->request_executed(op->request_hash);

--- a/pbft/pbft.cpp
+++ b/pbft/pbft.cpp
@@ -69,7 +69,7 @@ pbft::start()
                 this->node->register_for_message(bzn_envelope::PayloadCase::kPbftMembership,
                     std::bind(&pbft::handle_membership_message, shared_from_this(), std::placeholders::_1, std::placeholders::_2));
 
-                this->node->register_for_message("database",
+                this->node->register_for_message(bzn_envelope::kDatabaseMsg,
                         std::bind(&pbft::handle_database_message, shared_from_this(), std::placeholders::_1, std::placeholders::_2));
 
                 this->audit_heartbeat_timer->expires_from_now(HEARTBEAT_INTERVAL);
@@ -246,12 +246,11 @@ pbft::preliminary_filter_msg(const pbft_msg& msg)
 }
 
 std::shared_ptr<pbft_operation>
-pbft::setup_request_operation(const bzn::encoded_message& request, const request_hash_t& hash,
-    const std::shared_ptr<session_base>& session)
+pbft::setup_request_operation(const bzn_envelope& request_env, const std::shared_ptr<session_base>& session)
 {
     const uint64_t request_seq = this->next_issued_sequence_number++;
-    auto op = this->find_operation(this->view, request_seq, hash);
-    op->record_request(request);
+    auto op = this->find_operation(this->view, request_seq, this->crypto->hash(request_env));
+    op->record_request(request_env);
 
     if (session)
     {
@@ -262,12 +261,12 @@ pbft::setup_request_operation(const bzn::encoded_message& request, const request
 }
 
 void
-pbft::handle_request(const pbft_request& msg, const bzn::json_message& original_msg, const std::shared_ptr<session_base>& session)
+pbft::handle_request(const bzn_envelope& request_env, const std::shared_ptr<session_base>& session)
 {
     if (!this->is_primary())
     {
-        LOG(info) << "Forwarding request to primary: " << original_msg.toStyledString();
-        this->node->send_message(bzn::make_endpoint(this->get_primary()), std::make_shared<bzn::json_message>(original_msg));
+        LOG(info) << "Forwarding request to primary";
+        this->node->send_message(bzn::make_endpoint(this->get_primary()), std::make_shared<bzn_envelope>(request_env));
         return;
     }
 
@@ -279,8 +278,7 @@ pbft::handle_request(const pbft_request& msg, const bzn::json_message& original_
         return;
     }
 
-    auto smsg = original_msg.toStyledString();
-    auto hash = this->crypto->hash(smsg);
+    auto hash = this->crypto->hash(request_env);
 
     // keep track of what requests we've seen based on timestamp and only send preprepares once
     if (this->already_seen_request(msg, hash))
@@ -291,14 +289,15 @@ pbft::handle_request(const pbft_request& msg, const bzn::json_message& original_
     }
     this->saw_request(msg, hash);
 
-    auto op = setup_request_operation(smsg, hash, session);
+    //TODO: keep track of what requests we've seen based on timestamp and only send preprepares once - KEP-329
+    auto op = setup_request_operation(request_env, session);
     this->do_preprepare(op);
 }
 
 void
 pbft::maybe_record_request(const pbft_msg& msg, const std::shared_ptr<pbft_operation>& op)
 {
-    if (!msg.request().empty() && !op->has_request())
+    if (msg.has_request() && !op->has_request())
     {
         if (this->crypto->hash(msg.request()) != msg.request_hash())
         {
@@ -334,7 +333,7 @@ pbft::handle_preprepare(const pbft_msg& msg, const bzn_envelope& original_msg)
         // This assignment will be redundant if we've seen this preprepare before, but that's fine
         accepted_preprepares[log_key] = op->get_operation_key();
 
-        if (op->has_request() && op->get_request().type() == PBFT_REQ_NEW_CONFIG)
+        if (op->has_config_request())
         {
             this->handle_config_message(msg, op);
         }
@@ -427,7 +426,7 @@ pbft::handle_get_state(const pbft_membership_msg& msg, std::shared_ptr<bzn::sess
         reply.set_state_hash(req_cp.second);
         reply.set_state_data(this->get_checkpoint_state(req_cp));
 
-        auto msg_ptr = std::make_shared<bzn::encoded_message>(this->wrap_message(reply));
+        auto msg_ptr = std::make_shared<bzn::encoded_message>(this->wrap_message(reply).SerializeAsString());
         session->send_datagram(msg_ptr);
     }
     else
@@ -462,8 +461,21 @@ pbft::handle_set_state(const pbft_membership_msg& msg)
 }
 
 void
+pbft::broadcast(const bzn_envelope& msg)
+{
+    auto msg_ptr = std::make_shared<bzn_envelope>(msg);
+
+    for (const auto& peer : this->current_peers())
+    {
+        this->node->send_message(make_endpoint(peer), msg_ptr);
+    }
+}
+
+void
 pbft::broadcast(const bzn::encoded_message& msg)
 {
+    // broadcast(bzn_envelope) is preferred, this is kept for now because audit still uses json wrapping
+
     auto msg_ptr = std::make_shared<bzn::encoded_message>(msg);
 
     for (const auto& peer : this->current_peers())
@@ -504,7 +516,7 @@ pbft::do_preprepare(const std::shared_ptr<pbft_operation>& op)
     LOG(debug) << "Doing preprepare for operation " << op->debug_string();
 
     pbft_msg msg = this->common_message_setup(op, PBFT_MSG_PREPREPARE);
-    msg.set_request(op->get_encoded_request());
+    msg.set_allocated_request(new bzn_envelope(op->get_request()));
 
     this->broadcast(this->wrap_message(msg, "preprepare"));
 }
@@ -523,10 +535,10 @@ void
 pbft::do_prepared(const std::shared_ptr<pbft_operation>& op)
 {
     // accept new configuration if applicable
-    if (op->has_request() && op->get_request().type() == PBFT_REQ_NEW_CONFIG && op->get_request().has_config())
+    if (op->has_config_request())
     {
         pbft_configuration config;
-        if (config.from_string(op->get_request().config().configuration()))
+        if (config.from_string(op->get_config_request().configuration()))
         {
             this->configurations.enable(config.get_hash());
         }
@@ -544,10 +556,10 @@ void
 pbft::do_committed(const std::shared_ptr<pbft_operation>& op)
 {
     // commit new configuration if applicable
-    if (op->has_request() && op->get_request().type() == PBFT_REQ_NEW_CONFIG && op->get_request().has_config())
+    if (op->has_config_request())
     {
         pbft_configuration config;
-        if (config.from_string(op->get_request().config().configuration()))
+        if (config.from_string(op->get_config_request().configuration()))
         {
             // get rid of all other previous configs, except for currently active one
             this->configurations.remove_prior_to(config.get_hash());
@@ -568,7 +580,7 @@ pbft::do_committed(const std::shared_ptr<pbft_operation>& op)
     }
 
     // TODO: this needs to be refactored to be service-agnostic
-    if (op->get_request().type() == PBFT_REQ_DATABASE)
+    if (op->has_db_request())
     {
         this->io_context->post(std::bind(&pbft_service_base::apply_operation, this->service, this->find_operation(op)));
     }
@@ -577,12 +589,11 @@ pbft::do_committed(const std::shared_ptr<pbft_operation>& op)
         // the service needs sequentially sequenced operations. post a null request to fill in this hole
         auto msg = new database_msg;
         msg->set_allocated_nullmsg(new database_nullmsg);
-        pbft_request request;
-        request.set_allocated_operation(msg);
-        auto smsg = request.SerializeAsString();
+        bzn_envelope request;
+        request.set_database_msg(msg->SerializeAsString());
         auto new_op = std::make_shared<pbft_operation>(op->view, op->sequence
-            , this->crypto->hash(smsg), nullptr);
-        new_op->record_request(smsg);
+            , this->crypto->hash(request), nullptr);
+        new_op->record_request(request);
         this->io_context->post(std::bind(&pbft_service_base::apply_operation, this->service, new_op));
             request.SerializeAsString();
     }
@@ -640,24 +651,24 @@ pbft::find_operation(uint64_t view, uint64_t sequence, const bzn::hash_t& req_ha
     return lookup->second;
 }
 
-bzn::encoded_message
+bzn_envelope
 pbft::wrap_message(const pbft_msg& msg, const std::string& /*debug_info*/)
 {
     bzn_envelope result;
     result.set_pbft(msg.SerializeAsString());
     result.set_sender(this->uuid);
 
-    return result.SerializeAsString();
+    return result;
 }
 
-bzn::encoded_message
+bzn_envelope
 pbft::wrap_message(const pbft_membership_msg& msg, const std::string& /*debug_info*/) const
 {
     bzn_envelope result;
     result.set_pbft_membership(msg.SerializeAsString());
     result.set_sender(this->uuid);
 
-    return result.SerializeAsString();
+    return result;
 }
 
 bzn::encoded_message
@@ -821,8 +832,8 @@ pbft::request_checkpoint_state(const checkpoint_t& cp)
     LOG(info) << boost::format("Requesting checkpoint state for hash %1% at seq %2% from %3%")
         % cp.second % cp.first % selected.uuid;
 
-    auto msg_ptr = std::make_shared<bzn::encoded_message>(this->wrap_message(msg));
-    this->node->send_message_str(make_endpoint(selected), msg_ptr);
+    auto msg_ptr = std::make_shared<bzn_envelope>(this->wrap_message(msg));
+    this->node->send_message(make_endpoint(selected), msg_ptr);
 }
 
 const peer_address_t&
@@ -915,37 +926,18 @@ pbft::max_faulty_nodes() const
 }
 
 void
-pbft::handle_database_message(const bzn::json_message& json, std::shared_ptr<bzn::session_base> session)
+pbft::handle_database_message(const bzn_envelope& msg, std::shared_ptr<bzn::session_base> session)
 {
-    bzn_msg msg;
-    database_response response;
-
-    LOG(debug) << "got database message: " << json.toStyledString();
-
-    if (!json.isMember("msg"))
-    {
-        LOG(error) << "Invalid message: " << json.toStyledString().substr(0,MAX_MESSAGE_SIZE) << "...";
-        response.mutable_error()->set_message(bzn::MSG_INVALID_CRUD_COMMAND);
-        session->send_message(std::make_shared<bzn::encoded_message>(response.SerializeAsString()), true);
-        return;
-    }
-
-    if (!msg.ParseFromString(boost::beast::detail::base64_decode(json["msg"].asString())))
-    {
-        LOG(error) << "Failed to decode message: " << json.toStyledString().substr(0,MAX_MESSAGE_SIZE) << "...";
-        response.mutable_error()->set_message(bzn::MSG_INVALID_CRUD_COMMAND);
-        session->send_message(std::make_shared<bzn::encoded_message>(response.SerializeAsString()), true);
-        return;
-    }
-
     *response.mutable_header() = msg.db().header();
 
     pbft_request req;
     *req.mutable_operation() = msg.db();
     req.set_timestamp(this->now()); //TODO: the timestamp needs to come from the client
 
-    this->handle_request(req, json, session);
+    LOG(debug) << "got database message";
+    this->handle_request(msg, session);
 
+    database_response response;
     LOG(debug) << "Sending request ack: " << response.ShortDebugString();
     session->send_message(std::make_shared<bzn::encoded_message>(response.SerializeAsString()), false);
 }
@@ -1068,14 +1060,12 @@ pbft::get_peer_by_uuid(const std::string& uuid) const
 void
 pbft::broadcast_new_configuration(pbft_configuration::shared_const_ptr config)
 {
-    pbft_request req;
-    req.set_type(PBFT_REQ_NEW_CONFIG);
     auto cfg_msg = new pbft_config_msg;
     cfg_msg->set_configuration(config->to_string());
-    req.set_allocated_config(cfg_msg);
+    bzn_envelope req;
+    req.set_pbft_internal_request(cfg_msg->SerializeAsString());
 
-    auto smsg = req.SerializeAsString();
-    auto op  = this->setup_request_operation(smsg, this->crypto->hash(smsg));
+    auto op = this->setup_request_operation(req);
     this->do_preprepare(op);
 }
 
@@ -1088,10 +1078,9 @@ pbft::is_configuration_acceptable_in_new_view(hash_t config_hash)
 void
 pbft::handle_config_message(const pbft_msg& msg, const std::shared_ptr<pbft_operation>& op)
 {
-    auto const& request = op->get_request();
-    assert(request.type() == PBFT_REQ_NEW_CONFIG);
+    assert(op->has_config_request());
     auto config = std::make_shared<pbft_configuration>();
-    if (msg.type() == PBFT_MSG_PREPREPARE && config->from_string(request.config().configuration()))
+    if (msg.type() == PBFT_MSG_PREPREPARE && config->from_string(op->get_config_request().configuration()))
     {
         if (this->proposed_config_is_acceptable(config))
         {

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -117,6 +117,7 @@ namespace bzn
         
         pbft_msg common_message_setup(const std::shared_ptr<pbft_operation>& op, pbft_msg_type type);
         std::shared_ptr<pbft_operation> setup_request_operation(const bzn_envelope& msg
+            , const bzn::hash_t& request_hash
             , const std::shared_ptr<session_base>& session = nullptr);
 
         void broadcast(const bzn_envelope& message);

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -58,7 +58,7 @@ namespace bzn
 
         void handle_message(const pbft_msg& msg, const bzn_envelope& original_msg) override;
 
-        void handle_database_message(const bzn::json_message& json, std::shared_ptr<bzn::session_base> session);
+        void handle_database_message(const bzn_envelope& msg, std::shared_ptr<bzn::session_base> session);
 
         size_t outstanding_operations_count() const;
 
@@ -93,7 +93,7 @@ namespace bzn
 
         bool preliminary_filter_msg(const pbft_msg& msg);
 
-        void handle_request(const pbft_request& msg, const bzn::json_message& original_msg, const std::shared_ptr<session_base>& session = nullptr);
+        void handle_request(const bzn_envelope& request, const std::shared_ptr<session_base>& session = nullptr);
         void handle_preprepare(const pbft_msg& msg, const bzn_envelope& original_msg);
         void handle_prepare(const pbft_msg& msg, const bzn_envelope& original_msg);
         void handle_commit(const pbft_msg& msg, const bzn_envelope& original_msg);
@@ -111,14 +111,15 @@ namespace bzn
 
         void handle_bzn_message(const bzn_envelope& msg, std::shared_ptr<bzn::session_base> session);
         void handle_membership_message(const bzn_envelope& msg, std::shared_ptr<bzn::session_base> session = nullptr);
-        bzn::encoded_message wrap_message(const pbft_msg& message, const std::string& debug_info = "");
-        bzn::encoded_message wrap_message(const pbft_membership_msg& message, const std::string& debug_info = "") const;
+        bzn_envelope wrap_message(const pbft_msg& message, const std::string& debug_info = "");
+        bzn_envelope wrap_message(const pbft_membership_msg& message, const std::string& debug_info = "") const;
         bzn::encoded_message wrap_message(const audit_message& message, const std::string& debug_info = "");
         
         pbft_msg common_message_setup(const std::shared_ptr<pbft_operation>& op, pbft_msg_type type);
-        std::shared_ptr<pbft_operation> setup_request_operation(const bzn::encoded_message& msg
-            , const request_hash_t& hash, const std::shared_ptr<session_base>& session = nullptr);
+        std::shared_ptr<pbft_operation> setup_request_operation(const bzn_envelope& msg
+            , const std::shared_ptr<session_base>& session = nullptr);
 
+        void broadcast(const bzn_envelope& message);
         void broadcast(const bzn::encoded_message& message);
 
         void handle_audit_heartbeat_timeout(const boost::system::error_code& ec);

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -153,8 +153,8 @@ namespace bzn
         void maybe_record_request(const pbft_msg& msg, const std::shared_ptr<pbft_operation>& op);
 
         timestamp_t now() const;
-        bool already_seen_request(const pbft_request& msg, const request_hash_t& hash) const;
-        void saw_request(const pbft_request& msg, const request_hash_t& hash);
+        bool already_seen_request(const bzn_envelope& msg, const request_hash_t& hash) const;
+        void saw_request(const bzn_envelope& msg, const request_hash_t& hash);
 
 
         // Using 1 as first value here to distinguish from default value of 0 in protobuf

--- a/pbft/pbft_operation.cpp
+++ b/pbft/pbft_operation.cpp
@@ -86,6 +86,7 @@ pbft_operation::record_request(const bzn_envelope& wrapped_request)
         if (!this->parsed_db.ParseFromString(wrapped_request.database_msg()))
         {
             LOG(error) << "Failed to parse database request";
+            LOG(error) << wrapped_request.database_msg();
             return;
         }
     }

--- a/pbft/pbft_operation.cpp
+++ b/pbft/pbft_operation.cpp
@@ -32,7 +32,19 @@ pbft_operation::has_request() const
     return this->request_saved;
 }
 
-const pbft_request&
+bool
+pbft_operation::has_db_request() const
+{
+    return this->has_request() && this->request.payload_case() == bzn_envelope::kDatabaseMsg;
+}
+
+bool
+pbft_operation::has_config_request() const
+{
+    return this->has_request() && this->request.payload_case() == bzn_envelope::kPbftInternalRequest;
+}
+
+const bzn_envelope&
 pbft_operation::get_request() const
 {
     if (!this->request_saved)
@@ -40,33 +52,60 @@ pbft_operation::get_request() const
         throw std::runtime_error("Tried to get a request that is not saved");
     }
 
-    return this->parsed_request;
+    return this->request;
 }
 
-const bzn::encoded_message&
-pbft_operation::get_encoded_request() const
+const pbft_config_msg&
+pbft_operation::get_config_request() const
 {
-    if (!this->request_saved)
+    if (!this->has_config_request())
     {
-        throw std::runtime_error("Tried to get a request that is not saved");
+        throw std::runtime_error("Tried to get a config request that is not saved");
     }
 
-    return this->encoded_request;
+    return this->parsed_config;
+}
+
+const database_msg&
+pbft_operation::get_database_msg() const
+{
+    if (!this->has_db_request())
+    {
+        throw std::runtime_error("Tried to get a db request that is not saved");
+    }
+
+    return this->parsed_db;
 }
 
 void
-pbft_operation::record_request(const bzn::encoded_message& wrapped_request)
+pbft_operation::record_request(const bzn_envelope& wrapped_request)
 {
-    // not actually parsing the request because, for now, its still json
-    this->encoded_request = wrapped_request;
 
-    if (this->parsed_request.ParseFromString(wrapped_request))
+    if (wrapped_request.payload_case() == bzn_envelope::kDatabaseMsg)
     {
-        LOG(error) << "Tried to record request as something not a valid request (perhaps an old json request?)";
-        // We don't consider this a failure case, for now, because it could be an old json request
+        if (!this->parsed_db.ParseFromString(wrapped_request.database_msg()))
+        {
+            LOG(error) << "Failed to parse database request";
+            return;
+        }
+    }
+    else if (wrapped_request.payload_case() == bzn_envelope::kPbftInternalRequest)
+    {
+        if (!this->parsed_config.ParseFromString(wrapped_request.pbft_internal_request()))
+        {
+            LOG(error) << "Failed to parse pbft internal request";
+            return;
+        }
+    }
+    else
+    {
+        LOG(error) << "Tried to record request as envelope that does not actually contain a request type";
+        return;
     }
 
+    this->request = wrapped_request;
     this->request_saved = true;
+
 }
 
 void
@@ -149,7 +188,7 @@ pbft_operation::get_state() const
 std::string
 pbft_operation::debug_string() const
 {
-    return boost::str(boost::format("(v%1%, s%2%) - %3%") % this->view % this->sequence % this->parsed_request.ShortDebugString());
+    return boost::str(boost::format("(v%1%, s%2%) - %3%") % this->view % this->sequence % this->request.ShortDebugString());
 }
 
 void

--- a/pbft/pbft_operation.hpp
+++ b/pbft/pbft_operation.hpp
@@ -60,11 +60,15 @@ namespace bzn
 
         std::weak_ptr<bzn::session_base> session() const;
 
-        const pbft_request& get_request() const;
-        const bzn::encoded_message& get_encoded_request() const;
 
-        void record_request(const bzn::encoded_message& encoded_request);
+        void record_request(const bzn_envelope& encoded_request);
         bool has_request() const;
+        bool has_db_request() const;
+        bool has_config_request() const;
+
+        const bzn_envelope& get_request() const;
+        const pbft_config_msg& get_config_request() const;
+        const database_msg& get_database_msg() const;
 
         const uint64_t view;
         const uint64_t sequence;
@@ -85,8 +89,9 @@ namespace bzn
 
         std::weak_ptr<bzn::session_base> listener_session;
 
-        bzn::encoded_message encoded_request;
-        pbft_request parsed_request;
+        bzn_envelope request;
+        database_msg parsed_db;
+        pbft_config_msg parsed_config;
 
         bool request_saved = false;
     };

--- a/pbft/test/pbft_checkpoint_tests.cpp
+++ b/pbft/test/pbft_checkpoint_tests.cpp
@@ -46,7 +46,7 @@ namespace bzn::test
 
     TEST_F(pbft_checkpoint_test, test_checkpoint_messages_sent_on_execute)
     {
-        EXPECT_CALL(*mock_node, send_message_str(_, ResultOf(is_checkpoint, Eq(true))))
+        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_checkpoint, Eq(true))))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         this->build_pbft();

--- a/pbft/test/pbft_operation_test.cpp
+++ b/pbft/test/pbft_operation_test.cpp
@@ -39,7 +39,7 @@ namespace
     class pbft_operation_test : public Test
     {
     public:
-        pbft_request request;
+        bzn_envelope request;
         bzn::hash_t request_hash = "somehash";
         uint64_t view = 6;
         uint64_t sequence = 19;
@@ -51,6 +51,8 @@ namespace
         pbft_operation_test()
                 : op(view, sequence, request_hash, std::make_shared<std::vector<bzn::peer_address_t>>(TEST_PEER_LIST))
         {
+            database_msg msg;
+            request.set_database_msg(msg.SerializeAsString());
         }
     };
 
@@ -71,7 +73,7 @@ namespace
             bzn_envelope msg;
             msg.set_sender(peer.uuid);
             op.record_prepare(msg);
-            op.record_request("pretend this is a request");
+            op.record_request(this->request);
         }
 
         EXPECT_TRUE(this->op.is_prepared());
@@ -132,7 +134,7 @@ namespace
             bzn_envelope msg;
             msg.set_sender(peer.uuid);
             op.record_prepare(msg);
-            op.record_request("pretend this is a request");
+            op.record_request(this->request);
         }
 
         EXPECT_TRUE(this->op.is_prepared());

--- a/pbft/test/pbft_proto_test.cpp
+++ b/pbft/test/pbft_proto_test.cpp
@@ -55,6 +55,7 @@ namespace bzn
         create->set_value(std::string("value_" + std::to_string(this->index)));
         dmsg->set_allocated_create(create);
         request.set_database_msg(dmsg->SerializeAsString());
+        request.set_timestamp(this->now());
 
         pbft->handle_request(request);
 

--- a/pbft/test/pbft_proto_test.hpp
+++ b/pbft/test/pbft_proto_test.hpp
@@ -66,8 +66,8 @@ namespace bzn
         { return this->pbft->now(); }
 
         // send request to pbft
-        void handle_request(const pbft_request& msg, const bzn::json_message& original_msg, const std::shared_ptr<session_base>& session = nullptr)
-        { this->pbft->handle_request(msg, original_msg, session); }
+        void handle_request(const bzn_envelope& msg, const std::shared_ptr<session_base>& session = nullptr)
+        { this->pbft->handle_request(msg, session); }
     };
 }
 

--- a/pbft/test/pbft_proto_test.hpp
+++ b/pbft/test/pbft_proto_test.hpp
@@ -26,7 +26,7 @@ namespace bzn
         std::shared_ptr<pbft_operation> send_request();
 
         // send a preprepare message to SUT
-        void send_preprepare(uint64_t sequence, const bzn::encoded_message& request);
+        void send_preprepare(uint64_t sequence, const bzn_envelope& request);
 
         // send fake prepares from all nodes to SUT
         void send_prepares(uint64_t sequence, const bzn::hash_t& request_hash);

--- a/pbft/test/pbft_test_common.hpp
+++ b/pbft/test/pbft_test_common.hpp
@@ -47,15 +47,14 @@ namespace bzn::test
     class pbft_test : public Test
     {
     public:
-        bzn::json_message request_json;
-        pbft_request request_msg;
+        bzn_envelope request_msg;
 
         pbft_msg preprepare_msg;
         bzn_envelope default_original_msg;
 
         std::shared_ptr<bzn::asio::Mockio_context_base> mock_io_context =
                 std::make_shared<NiceMock<bzn::asio::Mockio_context_base >>();
-        std::shared_ptr<bzn::Mocknode_base> mock_node = std::make_shared<NiceMock<bzn::Mocknode_base >>();
+        std::shared_ptr<bzn::Mocknode_base> mock_node = std::make_shared<bzn::Mocknode_base>();
         std::shared_ptr<bzn::Mockpbft_failure_detector_base> mock_failure_detector =
                 std::make_shared<NiceMock<bzn::Mockpbft_failure_detector_base >>();
         std::shared_ptr<bzn::mock_pbft_service_base> mock_service =
@@ -75,7 +74,7 @@ namespace bzn::test
 
         bzn::execute_handler_t service_execute_handler;
         bzn::protobuf_handler message_handler;
-        bzn::message_handler database_handler;
+        bzn::protobuf_handler database_handler;
         bzn::protobuf_handler membership_handler;
 
         bzn::uuid_t uuid = TEST_NODE_UUID;
@@ -98,13 +97,13 @@ namespace bzn::test
 
     bzn_envelope wrap_pbft_membership_msg(const pbft_membership_msg& msg);
 
-    bzn::json_message
+    bzn_envelope
     wrap_request(const database_msg& msg);
 
-    bool is_preprepare(std::shared_ptr<std::string> msg);
-    bool is_prepare(std::shared_ptr<std::string> msg);
-    bool is_commit(std::shared_ptr<std::string> msg);
-    bool is_checkpoint(std::shared_ptr<std::string> msg);
+    bool is_preprepare(std::shared_ptr<bzn_envelope> msg);
+    bool is_prepare(std::shared_ptr<bzn_envelope> msg);
+    bool is_commit(std::shared_ptr<bzn_envelope> msg);
+    bool is_checkpoint(std::shared_ptr<bzn_envelope> msg);
     bool is_audit(std::shared_ptr<std::string> msg);
 
     bzn_envelope from(uuid_t uuid);

--- a/proto/bluzelle.proto
+++ b/proto/bluzelle.proto
@@ -20,18 +20,19 @@ message bzn_envelope
 {
     string sender = 1;
     bytes signature = 2;
+    uint64 timestamp = 3;
 
     oneof payload
     {
         bytes database_msg = 10;
         bytes pbft_internal_request = 11;
 
-        bytes database_response = 4;
-        bytes json = 5;
-        bytes audit = 6;
-        bytes pbft = 7;
-        bytes pbft_membership = 8;
-        bytes status_request = 9;
+        bytes database_response = 12;
+        bytes json = 13;
+        bytes audit = 14;
+        bytes pbft = 15;
+        bytes pbft_membership = 16;
+        bytes status_request = 17;
     }
 }
 

--- a/proto/bluzelle.proto
+++ b/proto/bluzelle.proto
@@ -23,7 +23,9 @@ message bzn_envelope
 
     oneof payload
     {
-        bytes pbft_request = 3;
+        bytes database_msg = 10;
+        bytes pbft_internal_request = 11;
+
         bytes database_response = 4;
         bytes json = 5;
         bytes audit = 6;

--- a/proto/pbft.proto
+++ b/proto/pbft.proto
@@ -15,6 +15,7 @@
 syntax = "proto3";
 
 import "database.proto";
+import "bluzelle.proto";
 
 message pbft_msg
 {
@@ -29,7 +30,7 @@ message pbft_msg
     bytes request_hash = 5;
 
     // most messages should only have the hash, not the original request
-    bytes request = 4;
+    bzn_envelope request = 4;
 
     // for checkpoints
     string state_hash = 6;
@@ -48,18 +49,6 @@ enum pbft_msg_type
     PBFT_MSG_PREPARE = 3;
     PBFT_MSG_COMMIT = 4;
     PBFT_MSG_CHECKPOINT = 5;
-}
-
-message pbft_request
-{
-    pbft_request_type type = 1;
-    oneof msg
-    {
-        database_msg operation = 2;
-        pbft_config_msg config = 3;
-    }
-    uint64 timestamp = 4;
-    string client = 5;
 }
 
 enum pbft_request_type

--- a/raft/raft.cpp
+++ b/raft/raft.cpp
@@ -227,7 +227,12 @@ raft::request_vote_request()
             // todo: use resolver on hostname...
             auto ep = boost::asio::ip::tcp::endpoint{boost::asio::ip::address_v4::from_string(peer.host), peer.port};
 
-            this->node->send_message(ep, std::make_shared<bzn::json_message>(bzn::create_request_vote_request(this->uuid, this->current_term, this->raft_log->size(), this->last_log_term)));
+            this->node->send_message_json(ep, std::make_shared<bzn::json_message>(bzn::create_request_vote_request(
+                                        this->uuid
+                                        , this->current_term
+                                        , this->raft_log->size()
+                                        , this->last_log_term
+                                )));
         }
         catch(const std::exception& ex)
         {
@@ -847,7 +852,7 @@ raft::notify_leader_status()
     for (const auto& peer : this->get_all_peers())
     {
         auto ep = boost::asio::ip::tcp::endpoint{boost::asio::ip::address_v4::from_string(peer.host), peer.port};
-        this->node->send_message(ep, json_ptr);
+        this->node->send_message_json(ep, json_ptr);
     }
 }
 
@@ -872,7 +877,7 @@ raft::notify_commit(size_t log_index, const std::string& operation)
     for (const auto& peer : this->get_all_peers())
     {
         auto ep = boost::asio::ip::tcp::endpoint{boost::asio::ip::address_v4::from_string(peer.host), peer.port};
-        this->node->send_message(ep, json_ptr);
+        this->node->send_message_json(ep, json_ptr);
     }
 }
 
@@ -917,7 +922,7 @@ raft::request_append_entries()
 
             LOG(debug) << "Sending request:\n" << req->toStyledString().substr(0, MAX_MESSAGE_SIZE) << "...";
 
-            this->node->send_message(ep, req);
+            this->node->send_message_json(ep, req);
         }
         catch(const std::exception& ex)
         {
@@ -1477,7 +1482,7 @@ raft::auto_add_peer_if_required()
     msg["bzn-api"] = "raft";
     msg["cmd"] = "get_peers";
     LOG(debug) << "RAFT - sending get_peers to [" << end_point.address().to_string() << ":" << end_point.port() << "]";
-    this->node->send_message(end_point, std::make_shared<bzn::json_message>(msg));
+    this->node->send_message_json(end_point, std::make_shared<bzn::json_message>(msg));
 }
 
 
@@ -1539,7 +1544,6 @@ raft::add_self_to_swarm()
     LOG(debug) << "RAFT sending add_peer command to the leader:\n" << request.toStyledString();
 
 
-
-    this->node->send_message(end_point, std::make_shared<bzn::json_message>(request));
+    this->node->send_message_json(end_point, std::make_shared<bzn::json_message>(request));
 }
 

--- a/raft/test/raft_add_peers_test.cpp
+++ b/raft/test/raft_add_peers_test.cpp
@@ -199,7 +199,7 @@ namespace bzn
         //  2) I'm the follower, here's the leader
         //  3) I'm a candidate, there might be an election happening, try later
         // We will handle the first option:
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).WillRepeatedly( Invoke(
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).WillRepeatedly( Invoke(
                 [&](const boost::asio::ip::tcp::endpoint& /*ep*/, std::shared_ptr<bzn::json_message> msg)
                 {
                     const auto request = *msg;
@@ -262,7 +262,7 @@ namespace bzn
         //  3) I'm a candidate, there might be an election happening, try later
         // Handling option 2, ask follower, follower returns Leader, ask leader
         bzn::json_message response;
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).WillRepeatedly( Invoke(
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).WillRepeatedly( Invoke(
                 [&](const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::json_message> msg)
                 {
                     const auto request = *msg;
@@ -353,7 +353,7 @@ namespace bzn
         //  1) I'm the leader here are the peers
         //  2) I'm the follower, here's the leader
         //  3) I'm a candidate, there might be an election happening, try later
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).WillRepeatedly( Invoke(
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).WillRepeatedly( Invoke(
                 [&](const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::json_message> msg)
                 {
                     static size_t count;
@@ -455,7 +455,7 @@ namespace bzn
         //  1) I'm the leader here are the peers
         //  2) I'm the follower, here's the leader
         //  3) I'm a candidate, there might be an election happening, try later
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).WillRepeatedly( Invoke(
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).WillRepeatedly( Invoke(
                 [&](const boost::asio::ip::tcp::endpoint& /*ep*/, std::shared_ptr<bzn::json_message> msg)
                 {
                     static size_t count;

--- a/raft/test/raft_test.cpp
+++ b/raft/test/raft_test.cpp
@@ -437,7 +437,7 @@ namespace bzn
 
         // we should see requests for votes... and then the Append Requests
         // The "+1" is raft asking if it is in the swarm
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2 + 1);
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2 + 1);
 
         // expire timer...
         wh(boost::system::error_code());
@@ -484,7 +484,7 @@ namespace bzn
         raft->start();
 
         // don't care about the handler...
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times(TEST_PEER_LIST.size());
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times(TEST_PEER_LIST.size());
 
         // expire timer...
         wh(boost::system::error_code());
@@ -538,7 +538,7 @@ namespace bzn
 
         // we should see requests for votes...
         std::vector<bzn::message_handler> mh_req;
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times(TEST_PEER_LIST.size() - 1).WillRepeatedly(Invoke(
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times(TEST_PEER_LIST.size() - 1).WillRepeatedly(Invoke(
             [&](const auto&, const auto& msg)
             {
                 EXPECT_EQ((*msg)["cmd"].asString(), "RequestVote");
@@ -549,7 +549,7 @@ namespace bzn
 
         // heartbeat timer expired and we should be sending requests...
         std::vector<bzn::message_handler> mh_resp;
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2).WillRepeatedly(Invoke(
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2).WillRepeatedly(Invoke(
             [&](const auto&, const auto& msg)
             {
                 EXPECT_EQ((*msg)["cmd"].asString(), "AppendEntries");
@@ -650,7 +650,7 @@ namespace bzn
         EXPECT_EQ(raft->get_status()["state"].asString(), "follower");
 
         // we should see requests...
-        EXPECT_CALL(*mock_node, send_message(_, _)).Times(11);
+        EXPECT_CALL(*mock_node, send_message_json(_, _)).Times(11);
 
         // expire election timer...
         wh(boost::system::error_code());
@@ -1092,7 +1092,7 @@ namespace bzn
         // let's try a raft in candidate state, expire timer...
         // the current state must be follower
         // don't care about the handler...
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times(TEST_PEER_LIST.size() - 1);
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times(TEST_PEER_LIST.size() - 1);
         wh(boost::system::error_code());
         EXPECT_EQ(raft->get_state(), bzn::raft_state::candidate);
 
@@ -1155,7 +1155,7 @@ namespace bzn
         // let's try a raft in candidate state, expire timer...
         // the current state must be follower
         // don't care about the handler...
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times(TEST_PEER_LIST.size() - 1);
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times(TEST_PEER_LIST.size() - 1);
         wh(boost::system::error_code());
         EXPECT_EQ(raft->get_state(), bzn::raft_state::candidate);
 
@@ -1203,7 +1203,7 @@ namespace bzn
         raft->in_a_swarm = true;
 
         // lets make this raft the leader by responding to requests for votes
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2);
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2);
 
         wh(boost::system::error_code());
 
@@ -1271,7 +1271,7 @@ namespace bzn
         raft->in_a_swarm = true;
 
         // lets make this raft the leader by responding to requests for votes
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2);
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2);
 
         wh(boost::system::error_code());
 
@@ -1371,7 +1371,7 @@ namespace bzn
         raft->in_a_swarm = true;
 
         // lets make this raft the leader by responding to requests for votes
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2);
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2);
 
         wh(boost::system::error_code());
 
@@ -1411,7 +1411,7 @@ namespace bzn
         EXPECT_FALSE(std::find(new_peers.begin(), new_peers.end(), new_peer) == new_peers.end());
 
 
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).WillRepeatedly(Invoke(
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).WillRepeatedly(Invoke(
                 [](const auto& /*session*/, const auto& /*msg*/)
                 {
                     //std::cout << msg->toStyledString();
@@ -1461,7 +1461,7 @@ namespace bzn
         raft->in_a_swarm = true;
 
         // lets make this raft the leader by responding to requests for votes
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2);
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2);
 
         wh(boost::system::error_code());
 
@@ -1539,7 +1539,7 @@ namespace bzn
         raft->in_a_swarm = true;
 
         // lets make this raft the leader by responding to requests for votes
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2);
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2);
 
         wh(boost::system::error_code());
 
@@ -1594,7 +1594,7 @@ namespace bzn
         raft->in_a_swarm = true;
 
         // lets make this raft the leader by responding to requests for votes
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2);
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times((TEST_PEER_LIST.size() - 1) * 2);
 
         wh(boost::system::error_code());
 
@@ -1827,7 +1827,7 @@ namespace bzn
         // expire election timer...
 
         // we should see requests...
-        EXPECT_CALL(*mock_node, send_message(_, _)).WillRepeatedly(
+        EXPECT_CALL(*mock_node, send_message_json(_, _)).WillRepeatedly(
                 Invoke([](const auto&, const auto& /*msg*/){
 
                 })
@@ -1901,7 +1901,7 @@ namespace bzn
         auto raft = this->start_raft(TEST_FOUR_PEER_LIST, asio_wait_handler, bzn_msg_handler);
 
         // we should see 3 vote requests once the raft under test becomes a candidate...
-        EXPECT_CALL(*mock_node, send_message(_, _))
+        EXPECT_CALL(*mock_node, send_message_json(_, _))
                 .WillRepeatedly(Invoke(
                         [&](const auto&, const auto& msg)
                         {
@@ -1990,7 +1990,7 @@ namespace bzn
 
         EXPECT_EQ(raft->get_state(), bzn::raft_state::leader);
 
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).WillRepeatedly(Invoke(
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).WillRepeatedly(Invoke(
                 [](const auto& /*session*/, const auto& msg)
                 {
                     std::cout << msg->toStyledString();
@@ -1999,7 +1999,7 @@ namespace bzn
 
         // attempting to add an invalid peer must fail
         {
-            EXPECT_CALL(*this->mock_node, send_message(_, _)).WillRepeatedly(Invoke(
+            EXPECT_CALL(*this->mock_node, send_message_json(_, _)).WillRepeatedly(Invoke(
                     [](const auto& /*session*/, const auto& /*msg*/)
                     {
                         //std::cout << msg->toStyledString();
@@ -2117,7 +2117,7 @@ namespace bzn
         raft->start();
 
         // we should see requests...
-        EXPECT_CALL(*mock_node, send_message(_, _)).WillRepeatedly(
+        EXPECT_CALL(*mock_node, send_message_json(_, _)).WillRepeatedly(
                 Invoke([](const auto&, const auto& /*msg*/){ })
         );
 
@@ -2183,7 +2183,7 @@ namespace bzn
         raft->start();
 
         // don't care about the handler...
-        EXPECT_CALL(*this->mock_node, send_message(_, _)).Times(TEST_PEER_LIST.size() );
+        EXPECT_CALL(*this->mock_node, send_message_json(_, _)).Times(TEST_PEER_LIST.size() );
 
         // expire timer...
         wh(boost::system::error_code());

--- a/scripts/crud
+++ b/scripts/crud
@@ -59,17 +59,9 @@ def send_request(node, uuid, msg, loop=False, ws=None):
     req["msg"] = base64.b64encode(msg.SerializeToString())
 
     if use_pbft:
-        msg_outer = bluzelle_pb2.wrapped_bzn_msg()
-        msg_outer.type = 1 # BZN_MSG_PBFT
+        msg_outer = bluzelle_pb2.bzn_envelope()
+        msg_outer.database_msg = msg.db.SerializeToString()
 
-        msg_inner = pbft_pb2.pbft_msg()
-        msg_inner.type = 1 # PBFT_MSG_REQUEST
-        msg_inner.request.operation.CopyFrom(msg.db)
-        msg_inner.request.client = "crud cli"
-        msg_inner.request.timestamp = 0 # TODO
-        msg_outer.payload = msg_inner.SerializeToString()
-
-        print("Sending: \n{}".format(msg_outer).expandtabs(4))
         ws.send_binary(msg_outer.SerializeToString())
         return
     else:


### PR DESCRIPTION
consistently handled, hashed as bzn_envelope. Breaks compatability with
old client version.