### PR TITLE
database.proto eliminate transaction_id and replace with nonce

### DIFF
--- a/crud/crud.cpp
+++ b/crud/crud.cpp
@@ -293,7 +293,7 @@ crud::handle_subscribe(const bzn::caller_id_t& /*caller_id*/, const database_msg
         database_response response;
 
         this->subscription_manager->subscribe(request.header().db_uuid(), request.subscribe().key(),
-            request.header().transaction_id(), response, session);
+            request.header().nonce(), response, session);
 
         this->send_response(request, bzn::storage_result::ok, std::move(response), session);
 
@@ -312,7 +312,7 @@ crud::handle_unsubscribe(const bzn::caller_id_t& /*caller_id*/, const database_m
         database_response response;
 
         this->subscription_manager->unsubscribe(request.header().db_uuid(), request.unsubscribe().key(),
-            request.unsubscribe().transaction_id(), response, session);
+            request.unsubscribe().nonce(), response, session);
 
         this->send_response(request, bzn::storage_result::ok, std::move(response), session);
 

--- a/crud/raft_crud.cpp
+++ b/crud/raft_crud.cpp
@@ -95,14 +95,14 @@ raft_crud::do_raft_task_routing(const bzn::json_message& msg, const database_msg
         case database_msg::kSubscribe:
         {
             this->subscription_manager->subscribe(request.header().db_uuid(), request.subscribe().key(),
-                request.header().transaction_id(), response, session);
+                request.header().nonce(), response, session);
         }
         break;
 
         case database_msg::kUnsubscribe:
         {
             this->subscription_manager->unsubscribe(request.header().db_uuid(), request.unsubscribe().key(),
-                request.unsubscribe().transaction_id(), response, session);
+                request.unsubscribe().nonce(), response, session);
         }
         break;
 
@@ -260,7 +260,7 @@ raft_crud::commit_create(const database_msg& msg)
 {
     if (this->storage->create(msg.header().db_uuid(), msg.create().key(), msg.create().value()) != bzn::storage_result::ok)
     {
-        LOG(error) << "Request:" <<msg.header().transaction_id() << " Create failed";
+        LOG(error) << "Request:" <<msg.header().nonce() << " Create failed";
         return false;
     }
 
@@ -273,7 +273,7 @@ raft_crud::commit_update(const database_msg& msg)
 {
     if (this->storage->update(msg.header().db_uuid(), msg.update().key(), msg.update().value()) != bzn::storage_result::ok)
     {
-        LOG(error) << "Request:" << msg.header().transaction_id() << " Update failed";
+        LOG(error) << "Request:" << msg.header().nonce() << " Update failed";
         return false;
     }
 
@@ -286,7 +286,7 @@ raft_crud::commit_delete(const database_msg& msg)
 {
     if (this->storage->remove(msg.header().db_uuid(), msg.delete_().key()) != bzn::storage_result::ok)
     {
-        LOG(error) << "Request:" << msg.header().transaction_id() << " Delete failed";
+        LOG(error) << "Request:" << msg.header().nonce() << " Delete failed";
         return false;
     }
 

--- a/crud/subscription_manager.cpp
+++ b/crud/subscription_manager.cpp
@@ -157,7 +157,7 @@ subscription_manager::notify_sessions(const bzn::uuid_t& uuid, const bool update
                         database_response resp;
 
                         resp.mutable_header()->set_db_uuid(uuid);
-                        resp.mutable_header()->set_transaction_id(subscription.first);
+                        resp.mutable_header()->set_nonce(subscription.first);
                         resp.mutable_subscription_update()->set_key(key);
 
                         if (!value.empty())

--- a/crud/test/crud_test.cpp
+++ b/crud/test/crud_test.cpp
@@ -28,7 +28,7 @@ TEST(crud, test_that_create_sends_proper_response)
     database_msg msg;
 
     msg.mutable_header()->set_db_uuid("uuid");
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create()->set_key("key");
     msg.mutable_create()->set_value("value");
 
@@ -41,7 +41,7 @@ TEST(crud, test_that_create_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.error().message(), bzn::MSG_DATABASE_NOT_FOUND);
         }));
 
@@ -57,7 +57,7 @@ TEST(crud, test_that_create_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
         }));
 
@@ -74,7 +74,7 @@ TEST(crud, test_that_create_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
         }));
 
@@ -87,7 +87,7 @@ TEST(crud, test_that_create_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::kError);
             ASSERT_EQ(resp.error().message(), bzn::MSG_RECORD_EXISTS);
         }));
@@ -102,7 +102,7 @@ TEST(crud, test_that_create_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::kError);
             ASSERT_EQ(resp.error().message(), bzn::MSG_KEY_SIZE_TOO_LARGE);
         }));
@@ -117,7 +117,7 @@ TEST(crud, test_that_create_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::kError);
             ASSERT_EQ(resp.error().message(), bzn::MSG_VALUE_SIZE_TOO_LARGE);
         }));
@@ -133,7 +133,7 @@ TEST(crud, test_that_read_sends_proper_response)
     database_msg msg;
 
     msg.mutable_header()->set_db_uuid("uuid");
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create_db();
 
     crud.handle_request("caller_id", msg, nullptr);
@@ -161,7 +161,7 @@ TEST(crud, test_that_read_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::kRead);
             ASSERT_EQ(resp.read().key(), "key");
             ASSERT_EQ(resp.read().value(), "value");
@@ -177,7 +177,7 @@ TEST(crud, test_that_read_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::kError);
             ASSERT_EQ(resp.error().message(), bzn::MSG_RECORD_NOT_FOUND);
         }));
@@ -196,7 +196,7 @@ TEST(crud, test_that_update_sends_proper_response)
     database_msg msg;
 
     msg.mutable_header()->set_db_uuid("uuid");
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create_db();
 
     crud.handle_request("caller_id", msg, nullptr);
@@ -225,7 +225,7 @@ TEST(crud, test_that_update_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
         }));
 
@@ -243,7 +243,7 @@ TEST(crud, test_that_update_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::kRead);
             ASSERT_EQ(resp.read().key(), "key");
             ASSERT_EQ(resp.read().value(), "updated");
@@ -260,7 +260,7 @@ TEST(crud, test_that_delete_sends_proper_response)
     database_msg msg;
 
     msg.mutable_header()->set_db_uuid("uuid");
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create_db();
 
     crud.handle_request("caller_id", msg, nullptr);
@@ -288,7 +288,7 @@ TEST(crud, test_that_delete_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
         }));
 
@@ -301,7 +301,7 @@ TEST(crud, test_that_delete_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::kError);
             ASSERT_EQ(resp.error().message(), bzn::MSG_RECORD_NOT_FOUND);
         }));
@@ -317,7 +317,7 @@ TEST(crud, test_that_has_sends_proper_response)
     database_msg msg;
 
     msg.mutable_header()->set_db_uuid("uuid");
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create_db();
 
     crud.handle_request("caller_id", msg, nullptr);
@@ -345,7 +345,7 @@ TEST(crud, test_that_has_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
         }));
 
@@ -359,7 +359,7 @@ TEST(crud, test_that_has_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::kError);
             ASSERT_EQ(resp.error().message(), bzn::MSG_RECORD_NOT_FOUND);
         }));
@@ -378,7 +378,7 @@ TEST(crud, test_that_keys_sends_proper_response)
     database_msg msg;
 
     msg.mutable_header()->set_db_uuid("uuid");
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create_db();
 
     crud.handle_request("caller_id", msg, nullptr);
@@ -410,7 +410,7 @@ TEST(crud, test_that_keys_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::kKeys);
             ASSERT_EQ(resp.keys().keys().size(), int(2));
             // keys are not returned in order created...
@@ -430,7 +430,7 @@ TEST(crud, test_that_keys_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "invalid-uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::kKeys);
             ASSERT_EQ(resp.keys().keys().size(), int(0));
         }));
@@ -449,7 +449,7 @@ TEST(crud, test_that_size_sends_proper_response)
     database_msg msg;
 
     msg.mutable_header()->set_db_uuid("uuid");
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create_db();
 
     crud.handle_request("caller_id", msg, nullptr);
@@ -477,7 +477,7 @@ TEST(crud, test_that_size_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::kSize);
             ASSERT_EQ(resp.size().bytes(), int32_t(5));
             ASSERT_EQ(resp.size().keys(), int32_t(1));
@@ -493,7 +493,7 @@ TEST(crud, test_that_size_sends_proper_response)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             ASSERT_EQ(resp.header().db_uuid(), "invalid-uuid");
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(123));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
             ASSERT_EQ(resp.response_case(), database_response::kSize);
             ASSERT_EQ(resp.size().bytes(), int32_t(0));
             ASSERT_EQ(resp.size().keys(), int32_t(0));
@@ -520,7 +520,7 @@ TEST(crud, test_that_subscribe_request_calls_subscription_manager)
     database_msg msg;
 
     msg.mutable_header()->set_db_uuid("uuid");
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_subscribe()->set_key("key");
 
     // nothing should happen...
@@ -530,7 +530,7 @@ TEST(crud, test_that_subscribe_request_calls_subscription_manager)
     auto mock_session = std::make_shared<bzn::Mocksession_base>();
 
     EXPECT_CALL(*mock_subscription_manager, subscribe(msg.header().db_uuid(), msg.subscribe().key(),
-        msg.header().transaction_id(), _, _));
+        msg.header().nonce(), _, _));
 
     EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>(), false));
 
@@ -552,9 +552,9 @@ TEST(crud, test_that_unsubscribe_request_calls_subscription_manager)
     database_msg msg;
 
     msg.mutable_header()->set_db_uuid("uuid");
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_unsubscribe()->set_key("key");
-    msg.mutable_unsubscribe()->set_transaction_id(321);
+    msg.mutable_unsubscribe()->set_nonce(321);
 
     // nothing should happen...
     crud.handle_request("caller_id", msg, nullptr);
@@ -562,7 +562,7 @@ TEST(crud, test_that_unsubscribe_request_calls_subscription_manager)
     auto mock_session = std::make_shared<bzn::Mocksession_base>();
 
     EXPECT_CALL(*mock_subscription_manager, unsubscribe(msg.header().db_uuid(), msg.unsubscribe().key(),
-        msg.unsubscribe().transaction_id(), _, _));
+        msg.unsubscribe().nonce(), _, _));
 
     EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>(), false));
 
@@ -580,7 +580,7 @@ TEST(crud, test_that_has_db_request_sends_proper_response)
     database_msg msg;
 
     msg.mutable_header()->set_db_uuid("uuid");
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_has_db();
 
     // nothing should happen...
@@ -610,7 +610,7 @@ TEST(crud, test_that_create_db_request_sends_proper_response)
     // create database...
     database_msg msg;
     msg.mutable_header()->set_db_uuid("uuid");
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create_db();
 
     auto mock_session = std::make_shared<bzn::Mocksession_base>();
@@ -651,7 +651,7 @@ TEST(crud, test_that_delete_db_sends_proper_response)
     // delete database...
     database_msg msg;
     msg.mutable_header()->set_db_uuid("uuid");
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_delete_db();
 
     auto mock_session = std::make_shared<bzn::Mocksession_base>();

--- a/crud/test/raft_crud_test.cpp
+++ b/crud/test/raft_crud_test.cpp
@@ -38,7 +38,7 @@ namespace
     bzn::json_message generate_generic_request(const bzn::uuid_t& uid, bzn_msg& msg)
     {
         msg.mutable_db()->mutable_header()->set_db_uuid(uid);
-        msg.mutable_db()->mutable_header()->set_transaction_id(85746);
+        msg.mutable_db()->mutable_header()->set_nonce(85746);
 
         bzn::json_message request;
 
@@ -191,7 +191,7 @@ TEST_F(raft_crud_test, test_that_follower_not_knowing_leader_fails_to_create)
         {
            database_response resp;
            ASSERT_TRUE(resp.ParseFromString(*msg));
-           EXPECT_EQ(resp.header().transaction_id(), uint64_t(85746));
+           EXPECT_EQ(resp.header().nonce(), uint64_t(85746));
            EXPECT_EQ(resp.header().db_uuid(), USER_UUID);
         }));
 
@@ -297,7 +297,7 @@ TEST_F(raft_crud_test, test_that_a_leader_fails_to_create_an_existing_record)
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
             EXPECT_EQ(resp.error().message(), bzn::MSG_RECORD_EXISTS);
-            EXPECT_EQ(resp.header().transaction_id(), uint64_t(85746));
+            EXPECT_EQ(resp.header().nonce(), uint64_t(85746));
         }));
 
     this->mh(request, this->mock_session);
@@ -489,7 +489,7 @@ TEST_F(raft_crud_test, test_that_a_leader_can_update)
         {
             database_response resp;
             ASSERT_TRUE(resp.ParseFromString(*msg));
-            EXPECT_EQ(resp.header().transaction_id(), uint64_t(85746));
+            EXPECT_EQ(resp.header().nonce(), uint64_t(85746));
         }));
 
     this->mh(request, this->mock_session);

--- a/crud/test/subscription_manager_test.cpp
+++ b/crud/test/subscription_manager_test.cpp
@@ -185,7 +185,7 @@ TEST(subscription_manager, test_that_subscriber_is_notified_for_create_and_updat
         database_msg msg;
 
         msg.mutable_header()->set_db_uuid(TEST_UUID);
-        msg.mutable_header()->set_transaction_id(123);
+        msg.mutable_header()->set_nonce(123);
         msg.mutable_create()->set_key("0");
         msg.mutable_create()->set_value("0");
 
@@ -195,7 +195,7 @@ TEST(subscription_manager, test_that_subscriber_is_notified_for_create_and_updat
                 database_response resp;
                 resp.ParseFromString(*msg);
                 ASSERT_EQ(resp.header().db_uuid(), TEST_UUID);
-                ASSERT_EQ(resp.header().transaction_id(), uint64_t(0));
+                ASSERT_EQ(resp.header().nonce(), uint64_t(0));
                 ASSERT_EQ(resp.response_case(), database_response::kSubscriptionUpdate);
                 ASSERT_EQ(resp.subscription_update().key(), "0");
                 ASSERT_EQ(resp.subscription_update().value(), "0");
@@ -208,7 +208,7 @@ TEST(subscription_manager, test_that_subscriber_is_notified_for_create_and_updat
                 database_response resp;
                 resp.ParseFromString(*msg);
                 ASSERT_EQ(resp.header().db_uuid(), TEST_UUID);
-                ASSERT_EQ(resp.header().transaction_id(), uint64_t(1234));
+                ASSERT_EQ(resp.header().nonce(), uint64_t(1234));
                 ASSERT_EQ(resp.response_case(), database_response::kSubscriptionUpdate);
                 ASSERT_EQ(resp.subscription_update().key(), "0");
                 ASSERT_EQ(resp.subscription_update().value(), "0");
@@ -223,7 +223,7 @@ TEST(subscription_manager, test_that_subscriber_is_notified_for_create_and_updat
         database_msg msg;
 
         msg.mutable_header()->set_db_uuid(TEST_UUID);
-        msg.mutable_header()->set_transaction_id(123);
+        msg.mutable_header()->set_nonce(123);
         msg.mutable_update()->set_key("1");
         msg.mutable_update()->set_value("1");
 
@@ -233,7 +233,7 @@ TEST(subscription_manager, test_that_subscriber_is_notified_for_create_and_updat
                 database_response resp;
                 resp.ParseFromString(*msg);
                 ASSERT_EQ(resp.header().db_uuid(), TEST_UUID);
-                ASSERT_EQ(resp.header().transaction_id(), uint64_t(4321));
+                ASSERT_EQ(resp.header().nonce(), uint64_t(4321));
                 ASSERT_EQ(resp.response_case(), database_response::kSubscriptionUpdate);
                 ASSERT_EQ(resp.subscription_update().key(), "1");
                 ASSERT_EQ(resp.subscription_update().value(), "1");
@@ -246,7 +246,7 @@ TEST(subscription_manager, test_that_subscriber_is_notified_for_create_and_updat
                 database_response resp;
                 resp.ParseFromString(*msg);
                 ASSERT_EQ(resp.header().db_uuid(), TEST_UUID);
-                ASSERT_EQ(resp.header().transaction_id(), uint64_t(0));
+                ASSERT_EQ(resp.header().nonce(), uint64_t(0));
                 ASSERT_EQ(resp.response_case(), database_response::kSubscriptionUpdate);
                 ASSERT_EQ(resp.subscription_update().key(), "1");
                 ASSERT_EQ(resp.subscription_update().value(), "1");
@@ -261,7 +261,7 @@ TEST(subscription_manager, test_that_subscriber_is_notified_for_create_and_updat
         database_msg msg;
 
         msg.mutable_header()->set_db_uuid(TEST_UUID);
-        msg.mutable_header()->set_transaction_id(123);
+        msg.mutable_header()->set_nonce(123);
         msg.mutable_delete_()->set_key("1");
 
         EXPECT_CALL(*mock_session1, send_datagram(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
@@ -270,7 +270,7 @@ TEST(subscription_manager, test_that_subscriber_is_notified_for_create_and_updat
                 database_response resp;
                 resp.ParseFromString(*msg);
                 ASSERT_EQ(resp.header().db_uuid(), TEST_UUID);
-                ASSERT_EQ(resp.header().transaction_id(), uint64_t(4321));
+                ASSERT_EQ(resp.header().nonce(), uint64_t(4321));
                 ASSERT_EQ(resp.response_case(), database_response::kSubscriptionUpdate);
                 ASSERT_EQ(resp.subscription_update().key(), "1");
                 ASSERT_EQ(resp.subscription_update().value(), "");
@@ -283,7 +283,7 @@ TEST(subscription_manager, test_that_subscriber_is_notified_for_create_and_updat
                 database_response resp;
                 resp.ParseFromString(*msg);
                 ASSERT_EQ(resp.header().db_uuid(), TEST_UUID);
-                ASSERT_EQ(resp.header().transaction_id(), uint64_t(0));
+                ASSERT_EQ(resp.header().nonce(), uint64_t(0));
                 ASSERT_EQ(resp.response_case(), database_response::kSubscriptionUpdate);
                 ASSERT_EQ(resp.subscription_update().key(), "1");
                 ASSERT_EQ(resp.subscription_update().value(), "");
@@ -329,7 +329,7 @@ TEST(subscription_manager, test_that_dead_session_is_removed_from_subscriber_lis
     database_msg msg;
 
     msg.mutable_header()->set_db_uuid(TEST_UUID);
-    msg.mutable_header()->set_transaction_id(0);
+    msg.mutable_header()->set_nonce(0);
     msg.mutable_update()->set_key("0");
     msg.mutable_update()->set_value("0");
 
@@ -344,7 +344,7 @@ TEST(subscription_manager, test_that_dead_session_is_removed_from_subscriber_lis
             database_response resp;
             resp.ParseFromString(*msg);
             ASSERT_EQ(resp.header().db_uuid(), TEST_UUID);
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(0));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(0));
             ASSERT_EQ(resp.response_case(), database_response::kSubscriptionUpdate);
             ASSERT_EQ(resp.subscription_update().key(), "0");
             ASSERT_EQ(resp.subscription_update().value(), "0");
@@ -357,7 +357,7 @@ TEST(subscription_manager, test_that_dead_session_is_removed_from_subscriber_lis
             database_response resp;
             resp.ParseFromString(*msg);
             ASSERT_EQ(resp.header().db_uuid(), TEST_UUID);
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(1));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(1));
             ASSERT_EQ(resp.response_case(), database_response::kSubscriptionUpdate);
             ASSERT_EQ(resp.subscription_update().key(), "0");
             ASSERT_EQ(resp.subscription_update().value(), "0");
@@ -379,7 +379,7 @@ TEST(subscription_manager, test_that_dead_session_is_removed_from_subscriber_lis
             database_response resp;
             resp.ParseFromString(*msg);
             ASSERT_EQ(resp.header().db_uuid(), TEST_UUID);
-            ASSERT_EQ(resp.header().transaction_id(), uint64_t(0));
+            ASSERT_EQ(resp.header().nonce(), uint64_t(0));
             ASSERT_EQ(resp.response_case(), database_response::kSubscriptionUpdate);
             ASSERT_EQ(resp.subscription_update().key(), "0");
             ASSERT_EQ(resp.subscription_update().value(), "0");

--- a/pbft/test/database_pbft_service_test.cpp
+++ b/pbft/test/database_pbft_service_test.cpp
@@ -97,7 +97,7 @@ TEST(database_pbft_service, test_that_executed_operation_fires_callback_with_ope
 
     database_msg msg;
     msg.mutable_header()->set_db_uuid(TEST_UUID);
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create()->set_key("key2");
     msg.mutable_create()->set_value("value2");
 
@@ -129,7 +129,7 @@ TEST(database_pbft_service, test_that_stored_operation_is_executed_in_order_and_
 
     database_msg msg;
     msg.mutable_header()->set_db_uuid(TEST_UUID);
-    msg.mutable_header()->set_transaction_id(uint64_t(123));
+    msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create()->set_key("key2");
     msg.mutable_create()->set_value("value2");
 
@@ -142,7 +142,7 @@ TEST(database_pbft_service, test_that_stored_operation_is_executed_in_order_and_
 
     ASSERT_EQ(uint64_t(0), dps.applied_requests_count());
 
-    msg.mutable_header()->set_transaction_id(uint64_t(321));
+    msg.mutable_header()->set_nonce(uint64_t(321));
     msg.mutable_create()->set_key("key3");
     msg.mutable_create()->set_value("value3");
 
@@ -157,7 +157,7 @@ TEST(database_pbft_service, test_that_stored_operation_is_executed_in_order_and_
 
     ASSERT_EQ(uint64_t(0), dps.applied_requests_count());
 
-    msg.mutable_header()->set_transaction_id(uint64_t(321));
+    msg.mutable_header()->set_nonce(uint64_t(321));
     msg.mutable_create()->set_key("key1");
     msg.mutable_create()->set_value("value1");
 
@@ -213,7 +213,7 @@ namespace test
     {
         database_msg msg;
         msg.mutable_header()->set_db_uuid(TEST_UUID);
-        msg.mutable_header()->set_transaction_id(uint64_t(seq));
+        msg.mutable_header()->set_nonce(uint64_t(seq));
         msg.mutable_create()->set_key("key" + std::to_string(seq));
         msg.mutable_create()->set_value("value" + std::to_string(seq));
 
@@ -226,7 +226,7 @@ namespace test
 
     uint64_t database_msg_seq(const database_msg& msg)
     {
-        return msg.header().transaction_id();
+        return msg.header().nonce();
     }
 }
 

--- a/pbft/test/pbft_test.cpp
+++ b/pbft/test/pbft_test.cpp
@@ -73,8 +73,8 @@ namespace bzn::test
         EXPECT_CALL(*mock_node, send_message(_, _)).WillRepeatedly(Invoke(save_sequences));
 
         database_msg req, req2;
-        req.mutable_header()->set_transaction_id(5);
-        req2.mutable_header()->set_transaction_id(1055);
+        req.mutable_header()->set_nonce(5);
+        req2.mutable_header()->set_nonce(1055);
 
         seen_sequences = std::set<uint64_t>();
         pbft->handle_database_message(wrap_request(req), this->mock_session);

--- a/proto/database.proto
+++ b/proto/database.proto
@@ -47,7 +47,7 @@ message database_msg
 message database_header
 {
     string db_uuid = 1;
-    uint64 transaction_id = 2;
+    uint64 nonce = 2;
 }
 
 message database_create
@@ -80,7 +80,7 @@ message database_subscribe
 message database_unsubscribe
 {
     string key = 1;
-    uint64 transaction_id = 2;
+    uint64 nonce = 2;
 }
 
 message database_has

--- a/raft/test/raft_test.cpp
+++ b/raft/test/raft_test.cpp
@@ -227,7 +227,7 @@ namespace
     {
         database_header* db_header = new database_header;
         db_header->set_db_uuid(uuid);
-        db_header->set_transaction_id(transaction_id);
+        db_header->set_nonce(transaction_id);
         return db_header;
     }
 


### PR DESCRIPTION
- PBFT requires a nonce to uniquely identify transactions
- The nonce can be used instead of transaction_id for the same purposes