### PR TITLE
KEP-843, KEP-845: Update crud script to handle new pbft response style,

### DIFF
--- a/mocks/mock_session_base.hpp
+++ b/mocks/mock_session_base.hpp
@@ -35,5 +35,7 @@ namespace bzn {
             bzn::session_id());
         MOCK_METHOD0(close,
             void());
+        MOCK_CONST_METHOD0(is_open,
+            bool());
     };
 }  // namespace bzn

--- a/node/session.cpp
+++ b/node/session.cpp
@@ -238,3 +238,9 @@ session::start_idle_timeout()
             }
         });
 }
+
+bool
+session::is_open() const
+{
+    return this->websocket->is_open();
+}

--- a/node/session.hpp
+++ b/node/session.hpp
@@ -45,6 +45,8 @@ namespace bzn
 
         bzn::session_id get_session_id() override { return this->session_id; }
 
+        bool is_open() const override;
+
     private:
         void do_read();
 

--- a/node/session_base.hpp
+++ b/node/session_base.hpp
@@ -66,6 +66,10 @@ namespace bzn
          */
         virtual void close() = 0;
 
+        /**
+         * Is the underlying socket open? (subject to race conditions)
+         */
+        virtual bool is_open() const = 0;
 
         /**
          * Get the id associated with this session

--- a/pbft/database_pbft_service.cpp
+++ b/pbft/database_pbft_service.cpp
@@ -93,7 +93,7 @@ database_pbft_service::process_awaiting_operations()
 
         auto op_it = this->operations_awaiting_result.find(this->next_request_sequence);
 
-        if (op_it != this->operations_awaiting_result.end() && op_it->second->has_session())
+        if (op_it != this->operations_awaiting_result.end() && op_it->second->has_session() && op_it->second->session()->is_open())
         {
             this->crud->handle_request("caller id", request, op_it->second->session());
         }

--- a/pbft/database_pbft_service.cpp
+++ b/pbft/database_pbft_service.cpp
@@ -95,17 +95,12 @@ database_pbft_service::process_awaiting_operations()
 
         if (op_it != this->operations_awaiting_result.end() && op_it->second->has_session())
         {
-
-            // session found, but is the connection still around?
-            auto session = op_it->second->session().lock();
-
-            LOG(info) << "We do not have a session for the result of this request";
-            this->crud->handle_request("caller id", request, (session) ? session : nullptr);
+            this->crud->handle_request("caller id", request, op_it->second->session());
         }
         else
         {
             // session not found then this was probably loaded from the database...
-            LOG(info) << "We do not have a session for the result of this request";
+            LOG(info) << "We do not have a pending operation for this request";
             this->crud->handle_request("caller_id", request, nullptr);
         }
 

--- a/pbft/dummy_pbft_service.cpp
+++ b/pbft/dummy_pbft_service.cpp
@@ -95,14 +95,6 @@ dummy_pbft_service::send_execute_response(const std::shared_ptr<pbft_operation>&
     database_response resp;
     resp.mutable_read()->set_value("dummy database execution of " + op->debug_string());
 
-    if (auto session = op->session().lock())
-    {
-        LOG(debug) << "Sending request result " << resp.ShortDebugString();
-
-        session->send_datagram(std::make_shared<std::string>(resp.SerializeAsString()));
-    }
-    else
-    {
-        LOG(debug) << "Session no longer valid, not sending request result " << resp.ShortDebugString();
-    }
+    LOG(debug) << "Sending request result " << resp.ShortDebugString();
+    op->session()->send_datagram(std::make_shared<std::string>(resp.SerializeAsString()));
 }

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -205,7 +205,7 @@ namespace bzn
 
         std::shared_ptr<crypto_base> crypto;
 
-        std::map<bzn::hash_t, std::weak_ptr<bzn::session_base>> sessions_waiting_on_forwarded_requests;
+        std::map<bzn::hash_t, std::shared_ptr<bzn::session_base>> sessions_waiting_on_forwarded_requests;
     };
 
 } // namespace bzn

--- a/pbft/pbft_operation.cpp
+++ b/pbft/pbft_operation.cpp
@@ -193,13 +193,13 @@ pbft_operation::debug_string() const
 }
 
 void
-pbft_operation::set_session(std::weak_ptr<bzn::session_base> session)
+pbft_operation::set_session(std::shared_ptr<bzn::session_base> session)
 {
     this->listener_session = std::move(session);
     this->session_saved = true;
 }
 
-std::weak_ptr<bzn::session_base>
+std::shared_ptr<bzn::session_base>
 pbft_operation::session() const
 {
     return this->listener_session;

--- a/pbft/pbft_operation.hpp
+++ b/pbft/pbft_operation.hpp
@@ -41,8 +41,8 @@ namespace bzn
 
         pbft_operation(uint64_t view, uint64_t sequence, const bzn::hash_t& request_hash, std::shared_ptr<const std::vector<peer_address_t>> peers);
 
-        void set_session(std::weak_ptr<bzn::session_base>);
-        std::weak_ptr<bzn::session_base> session() const;
+        void set_session(std::shared_ptr<bzn::session_base>);
+        std::shared_ptr<bzn::session_base> session() const;
         bool has_session() const;
 
         operation_key_t get_operation_key() const;
@@ -86,7 +86,7 @@ namespace bzn
         std::set<bzn::uuid_t> prepares_seen;
         std::set<bzn::uuid_t> commits_seen;
 
-        std::weak_ptr<bzn::session_base> listener_session;
+        std::shared_ptr<bzn::session_base> listener_session;
 
         bzn_envelope request;
         database_msg parsed_db;

--- a/pbft/test/database_pbft_service_test.cpp
+++ b/pbft/test/database_pbft_service_test.cpp
@@ -147,6 +147,7 @@ TEST(database_pbft_service, test_that_stored_operation_is_executed_in_order_and_
     msg.mutable_create()->set_value("value3");
 
     auto mock_session = std::make_shared<bzn::Mocksession_base>();
+    EXPECT_CALL(*mock_session, is_open()).WillRepeatedly(Return(true));
     auto operation3 = std::make_shared<bzn::pbft_operation>(0, 3, "somehashb", nullptr);
     env.set_database_msg(msg.SerializeAsString());
     operation3->record_request(env);
@@ -163,7 +164,9 @@ TEST(database_pbft_service, test_that_stored_operation_is_executed_in_order_and_
     auto operation1 = std::make_shared<bzn::pbft_operation>(0, 1, "somehashc", nullptr);
     env.set_database_msg(msg.SerializeAsString());
     operation1->record_request(env);
-    operation1->set_session(std::make_shared<bzn::Mocksession_base>());
+    auto session2 = std::make_shared<bzn::Mocksession_base>();
+    EXPECT_CALL(*session2, is_open()).WillRepeatedly(Return(true));
+    operation1->set_session(std::move(session2));
 
     EXPECT_CALL(*mock_io_context, post(_)).Times(3);
 

--- a/pbft/test/database_pbft_service_test.cpp
+++ b/pbft/test/database_pbft_service_test.cpp
@@ -177,7 +177,7 @@ TEST(database_pbft_service, test_that_stored_operation_is_executed_in_order_and_
                EXPECT_EQ(request.msg_case(), database_msg::kCreate);
                EXPECT_EQ(request.create().key(), "key1");
                EXPECT_EQ(request.create().value(), "value1");
-               ASSERT_FALSE(session); // operation1 session is no longer around
+               ASSERT_TRUE(session);
             }));
 
         EXPECT_CALL(*mock_crud, handle_request(_, _, _)).WillOnce(Invoke(

--- a/pbft/test/pbft_test.cpp
+++ b/pbft/test/pbft_test.cpp
@@ -178,7 +178,7 @@ namespace bzn::test
         this->build_pbft();
         auto mock_session = std::make_shared<NiceMock<bzn::Mocksession_base>>();
 
-        EXPECT_CALL(*mock_session, send_message(A<std::shared_ptr<std::string>>(), _)).Times(Exactly(1));
+        EXPECT_CALL(*mock_session, send_datagram(A<std::shared_ptr<std::string>>())).Times(Exactly(1));
 
         this->database_handler(this->request_msg, mock_session);
     }

--- a/scripts/crud
+++ b/scripts/crud
@@ -41,6 +41,21 @@ except ImportError as e:
 
 transaction_id = 0
 
+def handle_response(ws):
+
+    print("-" * 60 + '\n')
+
+    resp = database_pb2.database_response()
+    resp.ParseFromString(ws.recv())
+
+    if resp.WhichOneof('response') == 'redirect':
+        redirect_node = "{}:{}".format(resp.redirect.leader_host, resp.redirect.leader_port)
+        print("redirecting to leader at {}...\n".format(redirect_node).expandtabs(4))
+        resp = send_request(redirect_node, uuid, msg)
+    else:
+        print("Response: \n{}".format(resp).expandtabs(4))
+        print("-" * 60 + '\n')
+
 def send_request(node, uuid, msg, loop=False, ws=None):
     global transaction_id
 
@@ -63,23 +78,14 @@ def send_request(node, uuid, msg, loop=False, ws=None):
         msg_outer.database_msg = msg.db.SerializeToString()
 
         ws.send_binary(msg_outer.SerializeToString())
-        return
+
+        handle_response(ws)
+        resp = handle_response(ws)
+
     else:
         print("Sending: \n{}".format(msg).expandtabs(4))
         ws.send(json.dumps(req))
-
-    print("-" * 60 + '\n')
-
-    resp = database_pb2.database_response()
-    resp.ParseFromString(ws.recv())
-
-    if resp.WhichOneof('response') == 'redirect':
-        redirect_node = "{}:{}".format(resp.redirect.leader_host, resp.redirect.leader_port)
-        print("redirecting to leader at {}...\n".format(redirect_node).expandtabs(4))
-        resp = send_request(redirect_node, uuid, msg)
-    else:
-        print("Response: \n{}".format(resp).expandtabs(4))
-        print("-" * 60 + '\n')
+        resp = handle_response(ws)
 
     if loop:
         while 1:


### PR DESCRIPTION
fix some lingering bugs that prevented that response from being sent

the session is held as a shared_ptr instead of a weak_ptr because, between pbft's ack and crud's response, no operations are pending on that session and it will otherwise be cleaned up.