### PR TITLE
KEP-901: Request forwarded to dead primary causes endless viewchange …

### DIFF
--- a/pbft/pbft_failure_detector.cpp
+++ b/pbft/pbft_failure_detector.cpp
@@ -42,7 +42,12 @@ pbft_failure_detector::handle_timeout(boost::system::error_code /*ec*/)
     if (this->completed_requests.count(this->ordered_requests.front())  == 0)
     {
         LOG(error) << "Failure detector detected unexecuted request " << this->ordered_requests.front() << '\n';
-        this->start_timer();
+        this->ordered_requests.pop_front();
+        if (this->ordered_requests.size() > 0)
+        {
+            this->start_timer();
+        }
+
         this->io_context->post(std::bind(this->failure_handler));
         return;
     }

--- a/pbft/test/pbft_failure_detector_test.cpp
+++ b/pbft/test/pbft_failure_detector_test.cpp
@@ -125,9 +125,9 @@ namespace
         ASSERT_TRUE(this->failure_detected);
     }
 
-    TEST_F(pbft_failure_detector_test, timeout_restarts_timer)
+    TEST_F(pbft_failure_detector_test, timeout_doesnt_restart_timer)
     {
-        EXPECT_CALL(*(this->request_timer), expires_from_now(_)).Times(Exactly(2));
+        EXPECT_CALL(*(this->request_timer), expires_from_now(_)).Times(Exactly(1));
         this->build_failure_detector();
 
         this->failure_detector->request_seen(req_a);


### PR DESCRIPTION
…loop

Another quick one