### PR TITLE
KEP-899 We should not throw an exception in the case of attempting to…

### DIFF
--- a/pbft/test/database_pbft_service_test.cpp
+++ b/pbft/test/database_pbft_service_test.cpp
@@ -79,14 +79,8 @@ TEST(database_pbft_service, test_that_failed_storing_of_operation_does_not_throw
     bzn_envelope request;
     request.set_database_msg(dmsg.SerializeAsString());
     operation->record_request(request);
-    try
-    {
-        dps.apply_operation(operation);
-    }
-    catch(...)
-    {
-        FAIL() << "apply_operation must not throw in the case of attempting to add an existing database entry";
-    }
+
+    EXPECT_NO_THROW(dps.apply_operation(operation));
 }
 
 TEST(database_pbft_service, test_that_executed_operation_fires_callback_with_operation)

--- a/pbft/test/database_pbft_service_test.cpp
+++ b/pbft/test/database_pbft_service_test.cpp
@@ -62,7 +62,7 @@ TEST(database_pbft_service, test_that_on_construction_if_next_request_sequence_d
 }
 
 
-TEST(database_pbft_service, test_that_failed_storing_of_operation_throws)
+TEST(database_pbft_service, test_that_failed_storing_of_operation_does_not_throw_for_duplicate)
 {
     auto mock_storage = std::make_shared<bzn::Mockstorage_base>();
 
@@ -79,8 +79,14 @@ TEST(database_pbft_service, test_that_failed_storing_of_operation_throws)
     bzn_envelope request;
     request.set_database_msg(dmsg.SerializeAsString());
     operation->record_request(request);
-
-    EXPECT_THROW(dps.apply_operation(operation), std::runtime_error);
+    try
+    {
+        dps.apply_operation(operation);
+    }
+    catch(...)
+    {
+        FAIL() << "apply_operation must not throw in the case of attempting to add an existing database entry";
+    }
 }
 
 TEST(database_pbft_service, test_that_executed_operation_fires_callback_with_operation)


### PR DESCRIPTION
… perform a create operation that has already been performed, this is done by simply ignoring a request to create a entity that already exists

Do we need to perform this for other types of database operation?

After speaking to Edward, I decided to only return in the case that the database returns a message that the entity that we are trying to add to the database already exists, the exception will throw in the other cases.