### PR TITLE
KEP-1011 crud refactor to add send_message to node using uuid

### DIFF
--- a/chaos/test/chaos_test.cpp
+++ b/chaos/test/chaos_test.cpp
@@ -115,7 +115,7 @@ TEST_F(chaos_test, test_messages_sometimes_dropped_or_delayed_sometimes_not)
 
     for (int i=0; i<10000; i++)
     {
-        if(this->chaos->is_message_dropped())
+        if (this->chaos->is_message_dropped())
         {
             dropped_count ++;
         }
@@ -124,7 +124,7 @@ TEST_F(chaos_test, test_messages_sometimes_dropped_or_delayed_sometimes_not)
             not_dropped_count ++;
         }
 
-        if(this->chaos->is_message_delayed())
+        if (this->chaos->is_message_delayed())
         {
             delayed_count++;
         }

--- a/crud/crud.cpp
+++ b/crud/crud.cpp
@@ -14,6 +14,7 @@
 
 #include <crud/crud.hpp>
 #include <boost/algorithm/string/trim_all.hpp>
+#include <utils/make_endpoint.hpp>
 
 using namespace bzn;
 using namespace std::placeholders;
@@ -27,9 +28,10 @@ namespace
 }
 
 
-crud::crud(std::shared_ptr<bzn::storage_base> storage, std::shared_ptr<bzn::subscription_manager_base> subscription_manager)
+crud::crud(std::shared_ptr<bzn::storage_base> storage, std::shared_ptr<bzn::subscription_manager_base> subscription_manager, std::shared_ptr<bzn::node_base> node)
            : storage(std::move(storage))
            , subscription_manager(std::move(subscription_manager))
+           , node(std::move(node))
            , message_handlers{
                  {database_msg::kCreate,        std::bind(&crud::handle_create,         this, _1, _2, _3)},
                  {database_msg::kRead,          std::bind(&crud::handle_read,           this, _1, _2, _3)},
@@ -63,7 +65,7 @@ crud::start()
 
 
 void
-crud::handle_request(const bzn::caller_id_t& caller_id, const database_msg& request, const std::shared_ptr<bzn::session_base>& session)
+crud::handle_request(const bzn::caller_id_t& caller_id, const database_msg& request, const std::shared_ptr<bzn::session_base> session)
 {
     if (auto it = this->message_handlers.find(request.msg_case()); it != this->message_handlers.end())
     {
@@ -101,9 +103,31 @@ crud::send_response(const database_msg& request, const bzn::storage_result resul
     env.set_sender("placeholder for daemon's uuid"); // TODO
     // TODO: crypto
 
-    session->send_message(std::make_shared<std::string>(env.SerializeAsString()), false);
-}
+    if (session)
+    {
+        session->send_message(std::make_shared<std::string>(env.SerializeAsString()), false);
+    }
+    else
+    {
+        LOG(warning) << "session not set - response for the " << uint32_t(request.msg_case()) << " operation not sent via session";
+    }
 
+    if (this->node && !response.header().point_of_contact().empty())
+    {
+        try
+        {
+            this->node->send_message(response.header().point_of_contact(), std::make_shared<bzn_envelope>(env), false);
+        }
+        catch(const std::runtime_error& err)
+        {
+            LOG(error) << err.what();
+        }
+    }
+    else
+    {
+        LOG(error) << "Unable to send response for the " << uint32_t(request.msg_case()) << " operation to point of contact - node not set in crud module";
+    }
+}
 
 void
 crud::handle_create(const bzn::caller_id_t& caller_id, const database_msg& request, std::shared_ptr<bzn::session_base> session)
@@ -131,43 +155,28 @@ crud::handle_create(const bzn::caller_id_t& caller_id, const database_msg& reque
         }
     }
 
-    if (session)
-    {
-        this->send_response(request, result, database_response(), session);
-
-        return;
-    }
-
-    LOG(warning) << "session no longer available. CREATE response not sent.";
+    this->send_response(request, result, database_response(), session);
 }
 
 
 void
 crud::handle_read(const bzn::caller_id_t& /*caller_id*/, const database_msg& request, std::shared_ptr<bzn::session_base> session)
 {
-    if (session)
+    std::shared_lock<std::shared_mutex> lock(this->lock); // lock for read access
+
+    const bzn::key_t key = (request.msg_case() == database_msg::kRead) ? request.read().key() : request.quick_read().key();
+
+    const auto result = this->storage->read(request.header().db_uuid(), key);
+
+    database_response response;
+
+    if (result)
     {
-        std::shared_lock<std::shared_mutex> lock(this->lock); // lock for read access
-
-        const bzn::key_t key = (request.msg_case() == database_msg::kRead) ? request.read().key() : request.quick_read().key();
-
-        const auto result = this->storage->read(request.header().db_uuid(), key);
-
-        database_response response;
-
-        if (result)
-        {
-            response.mutable_read()->set_key(key);
-            response.mutable_read()->set_value(*result);
-        }
-
-        this->send_response(request, (result) ? bzn::storage_result::ok : bzn::storage_result::not_found,
-            std::move(response), session);
-
-        return;
+        response.mutable_read()->set_key(key);
+        response.mutable_read()->set_value(*result);
     }
 
-    LOG(warning) << "session no longer available. READ not executed.";
+    this->send_response(request, (result) ? bzn::storage_result::ok : bzn::storage_result::not_found, std::move(response), session);
 }
 
 
@@ -197,14 +206,7 @@ crud::handle_update(const bzn::caller_id_t& caller_id, const database_msg& reque
         }
     }
 
-    if (session)
-    {
-        this->send_response(request, result, database_response(), session);
-
-        return;
-    }
-
-    LOG(warning) << "session no longer available. UPDATE response not sent.";
+    this->send_response(request, result, database_response(), session);
 }
 
 
@@ -234,84 +236,56 @@ crud::handle_delete(const bzn::caller_id_t& caller_id, const database_msg& reque
         }
     }
 
-    if (session)
-    {
-        this->send_response(request, result, database_response(), session);
-
-        return;
-    }
-
-    LOG(warning) << "session no longer available. DELETE response not sent.";
+    this->send_response(request, result, database_response(), session);
 }
 
 
 void
 crud::handle_has(const bzn::caller_id_t& /*caller_id*/, const database_msg& request, std::shared_ptr<bzn::session_base> session)
 {
-    if (session)
-    {
-        std::shared_lock<std::shared_mutex> lock(this->lock); // lock for read access
+    std::shared_lock<std::shared_mutex> lock(this->lock); // lock for read access
 
-        database_response response;
+    database_response response;
 
-        response.mutable_has()->set_key(request.has().key());
-        response.mutable_has()->set_has(this->storage->has(request.header().db_uuid(), request.has().key()));
+    response.mutable_has()->set_key(request.has().key());
+    response.mutable_has()->set_has(this->storage->has(request.header().db_uuid(), request.has().key()));
 
-        this->send_response(request, bzn::storage_result::ok, std::move(response), session);
-
-        return;
-    }
-
-    LOG(warning) << "session no longer available. HAS not executed.";
+    this->send_response(request, bzn::storage_result::ok, std::move(response), session);
 }
 
 
 void
 crud::handle_keys(const bzn::caller_id_t& /*caller_id*/, const database_msg& request, std::shared_ptr<bzn::session_base> session)
 {
-    if (session)
+    std::shared_lock<std::shared_mutex> lock(this->lock); // lock for read access
+
+    const auto keys = this->storage->get_keys(request.header().db_uuid());
+
+    database_response response;
+    response.mutable_keys();
+
+    for (const auto& key : keys)
     {
-        std::shared_lock<std::shared_mutex> lock(this->lock); // lock for read access
-
-        const auto keys = this->storage->get_keys(request.header().db_uuid());
-
-        database_response response;
-        response.mutable_keys();
-
-        for (const auto& key : keys)
-        {
-            response.mutable_keys()->add_keys(key);
-        }
-
-        this->send_response(request, bzn::storage_result::ok, std::move(response), session);
-
-        return;
+        response.mutable_keys()->add_keys(key);
     }
 
-    LOG(warning) << "session no longer available. KEYS not executed.";
+    this->send_response(request, bzn::storage_result::ok, std::move(response), session);
 }
 
 
 void
 crud::handle_size(const bzn::caller_id_t& /*caller_id*/, const database_msg& request, std::shared_ptr<bzn::session_base> session)
 {
-    if (session)
-    {
-        std::shared_lock<std::shared_mutex> lock(this->lock); // lock for read access
+    std::shared_lock<std::shared_mutex> lock(this->lock); // lock for read access
 
-        const auto [keys, size] = this->storage->get_size(request.header().db_uuid());
+    const auto [keys, size] = this->storage->get_size(request.header().db_uuid());
 
-        database_response response;
+    database_response response;
 
-        response.mutable_size()->set_keys(keys);
-        response.mutable_size()->set_bytes(size);
+    response.mutable_size()->set_keys(keys);
+    response.mutable_size()->set_bytes(size);
 
-        this->send_response(request, bzn::storage_result::ok, std::move(response), session);
-
-        return;
-    }
-
-    LOG(warning) << "session no longer available. SIZE not executed.";
+    this->send_response(request, bzn::storage_result::ok, std::move(response), session);
 }
 
 
@@ -370,14 +344,7 @@ crud::handle_create_db(const bzn::caller_id_t& caller_id, const database_msg& re
         result = this->storage->create(PERMISSION_UUID, request.header().db_uuid(), this->create_permission_data(caller_id));
     }
 
-    if (session)
-    {
-        this->send_response(request, result, database_response(), session);
-
-        return;
-    }
-
-    LOG(warning) << "session no longer available. CREATE DB response not sent.";
+    this->send_response(request, result, database_response(), session);
 }
 
 
@@ -404,73 +371,51 @@ crud::handle_delete_db(const bzn::caller_id_t& caller_id, const database_msg& re
         }
     }
 
-    if (session)
-    {
-        this->send_response(request, result, database_response(), session);
-
-        return;
-    }
-
-    LOG(warning) << "session no longer available. DELETE DB response not sent.";
+    this->send_response(request, result, database_response(), session);
 }
 
 
 void
 crud::handle_has_db(const bzn::caller_id_t& /*caller_id*/, const database_msg& request, std::shared_ptr<bzn::session_base> session)
 {
-    if (session)
-    {
-        std::shared_lock<std::shared_mutex> lock(this->lock); // lock for read access
+    std::shared_lock<std::shared_mutex> lock(this->lock); // lock for read access
 
-        database_response response;
+    database_response response;
 
-        response.mutable_has_db()->set_uuid(request.header().db_uuid());
-        response.mutable_has_db()->set_has(this->storage->has(PERMISSION_UUID, request.header().db_uuid()));
+    response.mutable_has_db()->set_uuid(request.header().db_uuid());
+    response.mutable_has_db()->set_has(this->storage->has(PERMISSION_UUID, request.header().db_uuid()));
 
-        this->send_response(request, bzn::storage_result::ok, std::move(response), session);
-
-        return;
-    }
-
-    LOG(warning) << "session no longer available. HAS DB not executed.";
+    this->send_response(request, bzn::storage_result::ok, std::move(response), session);
 }
 
 
 void
 crud::handle_writers(const bzn::caller_id_t& /*caller_id*/, const database_msg& request, std::shared_ptr<bzn::session_base> session)
 {
-    if (session)
-    {
-        bzn::storage_result result{bzn::storage_result::not_found};
+     bzn::storage_result result{bzn::storage_result::not_found};
+     std::shared_lock<std::shared_mutex> lock(this->lock); // lock for read access
 
-        std::shared_lock<std::shared_mutex> lock(this->lock); // lock for read access
+     const auto [db_exists, perms] = this->get_database_permissions(request.header().db_uuid());
 
-        const auto [db_exists, perms] = this->get_database_permissions(request.header().db_uuid());
+     if (db_exists)
+     {
+         database_response resp;
 
-        if (db_exists)
-        {
-            database_response resp;
+         resp.mutable_writers()->set_owner(perms[OWNER_KEY].asString());
 
-            resp.mutable_writers()->set_owner(perms[OWNER_KEY].asString());
+         for(const auto& writer : perms[WRITERS_KEY])
+         {
+             resp.mutable_writers()->add_writers(writer.asString());
+         }
 
-            for(const auto& writer : perms[WRITERS_KEY])
-            {
-                resp.mutable_writers()->add_writers(writer.asString());
-            }
+         this->send_response(request, bzn::storage_result::ok, std::move(resp), session);
 
-            this->send_response(request, bzn::storage_result::ok, std::move(resp), session);
-
-            return;
-        }
-        else
-        {
-            this->send_response(request, result, database_response(), session);
-        }
-
-        return;
-    }
-
-    LOG(warning) << "session no longer available. WRITERS not executed.";
+         return;
+     }
+     else
+     {
+         this->send_response(request, result, database_response(), session);
+     }
 }
 
 
@@ -502,14 +447,7 @@ crud::handle_add_writers(const bzn::caller_id_t& caller_id, const database_msg& 
         }
     }
 
-    if (session)
-    {
-        this->send_response(request, result, database_response(), session);
-
-        return;
-    }
-
-    LOG(warning) << "session no longer available. ADD_WRITERS response not sent,";
+    this->send_response(request, result, database_response(), session);
 }
 
 
@@ -541,14 +479,7 @@ crud::handle_remove_writers(const bzn::caller_id_t& caller_id, const database_ms
         }
     }
 
-    if (session)
-    {
-        this->send_response(request, result, database_response(), session);
-
-        return;
-    }
-
-    LOG(warning) << "session no longer available. REMOVE_WRITERS response not sent,";
+    this->send_response(request, result, database_response(), session);
 }
 
 

--- a/crud/crud.hpp
+++ b/crud/crud.hpp
@@ -27,9 +27,9 @@ namespace bzn
     class crud final : public bzn::crud_base, public std::enable_shared_from_this<crud>
     {
     public:
-        crud(std::shared_ptr<bzn::storage_base> storage, std::shared_ptr<bzn::subscription_manager_base> subscription_manager);
+        crud(std::shared_ptr<bzn::storage_base> storage, std::shared_ptr<bzn::subscription_manager_base> subscription_manager, std::shared_ptr<bzn::node_base> node);
 
-        void handle_request(const bzn::caller_id_t& caller_id, const database_msg& request, const std::shared_ptr<bzn::session_base>& session) override;
+        void handle_request(const bzn::caller_id_t& caller_id, const database_msg& request, std::shared_ptr<bzn::session_base> session) override;
 
         void start() override;
 
@@ -71,8 +71,7 @@ namespace bzn
 
         void handle_remove_writers(const bzn::caller_id_t& caller_id, const database_msg& request, std::shared_ptr<bzn::session_base> session);
 
-        void send_response(const database_msg& request, bzn::storage_result result, database_response&& response,
-                           std::shared_ptr<bzn::session_base>& session);
+        void send_response(const database_msg& request, bzn::storage_result result, database_response&& response, std::shared_ptr<bzn::session_base>& session);
 
         // helpers...
         std::pair<bool, Json::Value> get_database_permissions(const bzn::uuid_t& uuid) const;
@@ -88,7 +87,10 @@ namespace bzn
         void remove_writers(const database_msg& request, Json::Value& perms);
 
         std::shared_ptr<bzn::storage_base> storage;
+
         std::shared_ptr<bzn::subscription_manager_base> subscription_manager;
+
+        std::shared_ptr<bzn::node_base> node;
 
         using message_handler_t = std::function<void(const bzn::caller_id_t& caller_id, const database_msg& request, std::shared_ptr<bzn::session_base> session)>;
 

--- a/crud/crud_base.hpp
+++ b/crud/crud_base.hpp
@@ -57,7 +57,7 @@ namespace bzn
     public:
         virtual ~crud_base() = default;
 
-        virtual void handle_request(const bzn::caller_id_t& caller_id, const database_msg& request, const std::shared_ptr<bzn::session_base>& session) = 0;
+        virtual void handle_request(const bzn::caller_id_t& caller_id, const database_msg& request, std::shared_ptr<bzn::session_base> session) = 0;
 
         virtual void start() = 0;
 

--- a/crud/test/CMakeLists.txt
+++ b/crud/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(test_srcs raft_crud_test.cpp crud_test.cpp subscription_manager_test.cpp)
-set(test_libs crud node storage bootstrap raft proto ${Protobuf_LIBRARIES})
+set(test_libs crud raft pbft pbft_operations node storage bootstrap proto ${Protobuf_LIBRARIES})
 
 add_gmock_test(crud)

--- a/crypto/crypto.cpp
+++ b/crypto/crypto.cpp
@@ -29,7 +29,7 @@ crypto::crypto(std::shared_ptr<bzn::options_base> options)
         : options(std::move(options))
 {
     LOG(info) << "Using " << SSLeay_version(SSLEAY_VERSION);
-    if(this->options->get_simple_options().get<bool>(bzn::option_names::CRYPTO_ENABLED_OUTGOING))
+    if (this->options->get_simple_options().get<bool>(bzn::option_names::CRYPTO_ENABLED_OUTGOING))
     {
         this->load_private_key();
     }
@@ -246,7 +246,7 @@ crypto::hash(const std::string& msg)
             && (1 == EVP_DigestUpdate(context.get(), msg.c_str(), msg.size()))
             && (1 == EVP_DigestFinal_ex(context.get(), hash_buffer.get(), NULL));
 
-    if(!success)
+    if (!success)
     {
         this->log_openssl_errors();
         throw std::runtime_error(std::string("\nfailed to compute message hash ") + msg);

--- a/mocks/mock_crud_base.hpp
+++ b/mocks/mock_crud_base.hpp
@@ -39,7 +39,7 @@ namespace bzn {
     class Mockcrud_base : public crud_base {
     public:
         MOCK_METHOD3(handle_request,
-            void(const bzn::caller_id_t& caller_id, const database_msg& request, const std::shared_ptr<bzn::session_base>& session));
+            void(const bzn::caller_id_t& caller_id, const database_msg& request, std::shared_ptr<bzn::session_base> session));
         MOCK_METHOD0(start,
             void());
         MOCK_METHOD0(save_state,

--- a/mocks/mock_node_base.hpp
+++ b/mocks/mock_node_base.hpp
@@ -28,14 +28,18 @@ class Mocknode_base : public node_base {
       bool(const std::string& msg_type, bzn::message_handler message_handler));
   MOCK_METHOD2(register_for_message,
       bool(const bzn_envelope::PayloadCase msg_type, bzn::protobuf_handler message_handler));
-  MOCK_METHOD0(start,
-      void());
+  MOCK_METHOD1(start,
+      void(std::shared_ptr<bzn::pbft_base> pbft));
   MOCK_METHOD2(send_message_json,
       void(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::json_message> msg));
   MOCK_METHOD3(send_message,
       void(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn_envelope> msg, bool close_session));
   MOCK_METHOD3(send_message_str,
       void(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::encoded_message> msg, bool close_session));
+  MOCK_METHOD3(send_message,
+      void(const bzn::uuid_t &uuid, std::shared_ptr<bzn_envelope> msg, bool close_session));
+  MOCK_METHOD1(set_consensus,
+      void(const std::shared_ptr<bzn::pbft_base>& pbft));
 };
 
 }  // namespace bzn

--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(node STATIC
         session.cpp
         ../mocks/mock_session_base.hpp)
 
-target_link_libraries(node proto)
+target_link_libraries(node proto pbft)
 add_dependencies(node proto googletest jsoncpp) # for FRIEND_TEST
 
 target_include_directories(node PRIVATE ${JSONCPP_INCLUDE_DIRS} ${PROTO_INCLUDE_DIR})

--- a/node/node.hpp
+++ b/node/node.hpp
@@ -19,6 +19,7 @@
 #include <chaos/chaos_base.hpp>
 #include <crypto/crypto_base.hpp>
 #include <options/options_base.hpp>
+#include <pbft/pbft_base.hpp>
 #include <json/json.h>
 #include <mutex>
 #include <atomic>
@@ -28,6 +29,8 @@
 
 namespace bzn
 {
+    class pbft;
+
     class node final : public bzn::node_base, public std::enable_shared_from_this<node>
     {
     public:
@@ -38,13 +41,15 @@ namespace bzn
 
         bool register_for_message(const bzn_envelope::PayloadCase type, bzn::protobuf_handler msg_handler) override;
 
-        void start() override;
+        void start(std::shared_ptr<bzn::pbft_base> pbft) override;
 
         void send_message_json(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::json_message> msg) override;
 
         void send_message(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn_envelope> msg, bool close_session) override;
 
         void send_message_str(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::encoded_message> msg, bool close_session) override;
+
+        void send_message(const bzn::uuid_t &uuid, std::shared_ptr<bzn_envelope> msg, bool close_session) override;
 
     private:
         FRIEND_TEST(node, test_that_registered_message_handler_is_invoked);
@@ -55,6 +60,7 @@ namespace bzn
         void priv_msg_handler(const bzn::json_message& msg, std::shared_ptr<bzn::session_base> session);
         void priv_protobuf_handler(const bzn_envelope& msg, std::shared_ptr<bzn::session_base> session);
 
+        std::shared_ptr<bzn::pbft_base>               pbft;
         std::unique_ptr<bzn::asio::tcp_acceptor_base> tcp_acceptor;
         std::shared_ptr<bzn::asio::io_context_base>   io_context;
         std::unique_ptr<bzn::asio::tcp_socket_base>   acceptor_socket;

--- a/node/node_base.hpp
+++ b/node/node_base.hpp
@@ -22,6 +22,8 @@
 
 namespace bzn
 {
+    class pbft_base;
+
     class node_base
     {
     public:
@@ -46,7 +48,7 @@ namespace bzn
         /**
          * Start server's listener etc.
          */
-        virtual void start() = 0;
+        virtual void start(std::shared_ptr<bzn::pbft_base> pbft) = 0;
 
         /**
          * Convenience method to connect and send a message to a node
@@ -71,6 +73,14 @@ namespace bzn
          * @param close_session don't expect a response on this session
          */
         virtual void send_message_str(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::encoded_message> msg, bool close_session) = 0;
+
+        /*
+         * Convenience method to connect and send a database message to a node by the node's uuid
+         * @param uuid          host to send the message to
+         * @param msg           message to send
+         * @param close_session don't expect a response on this session
+         */
+        virtual void send_message(const bzn::uuid_t &uuid, std::shared_ptr<bzn_envelope> msg, bool close_session) = 0;
     };
 
 } // bzn

--- a/node/test/node_test.cpp
+++ b/node/test/node_test.cpp
@@ -106,7 +106,7 @@ namespace  bzn
             }));
 
         auto node = std::make_shared<bzn::node>(mock_io_context, mock_websocket, mock_chaos, std::chrono::milliseconds(0), TEST_ENDPOINT, crypto, options);
-        node->start();
+        node->start(nullptr);
 
         // call the handler to test do_accept() is not called on error and do_accept() is called again...
         accept_handler(boost::asio::error::operation_aborted);
@@ -115,7 +115,7 @@ namespace  bzn
         accept_handler(boost::system::error_code());
 
         // calling start again should not call do_accept()...
-        node->start();
+        node->start(nullptr);
     }
 
 
@@ -283,7 +283,7 @@ namespace  bzn
                 session->send_message(std::make_shared<bzn::json_message>(msg), true);
             });
 
-        node->start();
+        node->start(nullptr);
 
         io_context->run();
     }

--- a/options/test/options_test.cpp
+++ b/options/test/options_test.cpp
@@ -97,7 +97,7 @@ public:
 
     void save_file(const std::string& filename, const std::string& content)
     {
-        if(this->open_files.count(filename) > 0)
+        if (this->open_files.count(filename) > 0)
         {
             unlink(TEST_CONFIG_FILE.c_str());
         }

--- a/pbft/database_pbft_service.cpp
+++ b/pbft/database_pbft_service.cpp
@@ -88,7 +88,7 @@ database_pbft_service::apply_operation_now(const bzn_envelope& msg, std::shared_
         {
             LOG(debug) << "handling quick read";
 
-            this->crud->handle_request(msg.sender(), db_msg, std::move(session));
+            this->crud->handle_request(msg.sender(), db_msg, session);
 
             return true;
         }

--- a/pbft/operations/pbft_operation_manager.cpp
+++ b/pbft/operations/pbft_operation_manager.cpp
@@ -23,7 +23,7 @@ using namespace bzn;
 pbft_operation_manager::pbft_operation_manager(std::optional<std::shared_ptr<bzn::storage_base>> storage)
     : storage(storage)
 {
-    if(!storage)
+    if (!storage)
     {
         LOG(warning) << "pbft operation operation manager constructed without a storage backend; operations will not be persistent";
     }
@@ -43,7 +43,7 @@ pbft_operation_manager::find_or_construct(uint64_t view, uint64_t sequence, cons
         LOG(debug) << "Creating operation for seq " << sequence << " view " << view << " req " << bytes_to_debug_string(request_hash);
 
         std::shared_ptr<pbft_operation> op;
-        if(this->storage)
+        if (this->storage)
         {
             op = std::make_shared<pbft_persistent_operation>(view, sequence, request_hash, *(this->storage), peers_list->size());
         }

--- a/pbft/operations/pbft_persistent_operation.cpp
+++ b/pbft/operations/pbft_persistent_operation.cpp
@@ -55,7 +55,7 @@ pbft_persistent_operation::pbft_persistent_operation(uint64_t view, uint64_t seq
 void
 pbft_persistent_operation::record_pbft_msg(const pbft_msg& msg, const bzn_envelope& encoded_msg)
 {
-    if(msg.type() != pbft_msg_type::PBFT_MSG_PREPREPARE
+    if (msg.type() != pbft_msg_type::PBFT_MSG_PREPREPARE
        && msg.type() != pbft_msg_type::PBFT_MSG_PREPARE
        && msg.type() != pbft_msg_type::PBFT_MSG_COMMIT)
     {
@@ -184,7 +184,7 @@ pbft_persistent_operation::load_transient_request() const
     }
 
     const auto response = this->storage->read(this->prefix, REQUEST_KEY);
-    if(!response.has_value())
+    if (!response.has_value())
     {
         return;
     }

--- a/pbft/pbft.cpp
+++ b/pbft/pbft.cpp
@@ -1074,6 +1074,12 @@ pbft::get_view() const
     return this->view;
 }
 
+std::shared_ptr<bzn::node_base>
+pbft::get_node()
+{
+    return this->node;
+}
+
 bool
 pbft::is_peer(const bzn::uuid_t& sender) const
 {

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -100,6 +100,10 @@ namespace bzn
 
         bool is_valid_newview_message(const pbft_msg& theirs, const bzn_envelope& original_theirs) const;
 
+        std::shared_ptr<bzn::node_base> get_node();
+
+        const peer_address_t& get_peer_by_uuid(const std::string& uuid) const override;
+
         /*
          * maximum number of tolerable faults (this can be a parameter, but for now we assume it has the worst-case value)
          * f = floor( (n-1) / 3 )
@@ -174,7 +178,7 @@ namespace bzn
         bool initialize_configuration(const bzn::peers_list_t& peers);
         std::shared_ptr<const std::vector<bzn::peer_address_t>> current_peers_ptr() const;
         const std::vector<bzn::peer_address_t>& current_peers() const;
-        const peer_address_t& get_peer_by_uuid(const std::string& uuid) const;
+
         void broadcast_new_configuration(pbft_configuration::shared_const_ptr config, const std::string& join_request_hash);
         bool is_configuration_acceptable_in_new_view(const hash_t& config_hash);
         bool move_to_new_configuration(const hash_t& config_hash);

--- a/pbft/pbft_base.hpp
+++ b/pbft/pbft_base.hpp
@@ -43,6 +43,8 @@ namespace bzn
 
         virtual void handle_failure() = 0;
 
+        virtual const peer_address_t& get_peer_by_uuid(const std::string& uuid) const = 0;
+
         virtual ~pbft_base() = default;
 
     };

--- a/pbft/test/database_pbft_service_test.cpp
+++ b/pbft/test/database_pbft_service_test.cpp
@@ -215,30 +215,27 @@ TEST(database_pbft_service, test_that_stored_operation_is_executed_in_order_and_
         InSequence dummy;
 
         EXPECT_CALL(*mock_crud, handle_request(_, _, _)).WillOnce(Invoke(
-            [](const bzn::caller_id_t& /*caller_id*/, const database_msg& request, const std::shared_ptr<bzn::session_base>& session)
+            [](const bzn::caller_id_t& /*caller_id*/, const database_msg& request, const std::shared_ptr<bzn::session_base> /*session*/)
             {
                EXPECT_EQ(request.msg_case(), database_msg::kCreate);
                EXPECT_EQ(request.create().key(), "key1");
                EXPECT_EQ(request.create().value(), "value1");
-               ASSERT_TRUE(session);
             }));
 
         EXPECT_CALL(*mock_crud, handle_request(_, _, _)).WillOnce(Invoke(
-            [](const bzn::caller_id_t& /*caller_id*/, const database_msg& request, const std::shared_ptr<bzn::session_base>& session)
+            [](const bzn::caller_id_t& /*caller_id*/, const database_msg& request, const std::shared_ptr<bzn::session_base> /*session*/)
             {
                 EXPECT_EQ(request.msg_case(), database_msg::kCreate);
                 EXPECT_EQ(request.create().key(), "key2");
                 EXPECT_EQ(request.create().value(), "value2");
-                ASSERT_FALSE(session); // operation2 never had a session set
             }));
 
         EXPECT_CALL(*mock_crud, handle_request(_, _, _)).WillOnce(Invoke(
-            [](const bzn::caller_id_t& /*caller_id*/, const database_msg& request, const std::shared_ptr<bzn::session_base>& session)
+            [](const bzn::caller_id_t& /*caller_id*/, const database_msg& request, const std::shared_ptr<bzn::session_base> /*session*/)
             {
                 EXPECT_EQ(request.msg_case(), database_msg::kCreate);
                 EXPECT_EQ(request.create().key(), "key3");
                 EXPECT_EQ(request.create().value(), "value3");
-                ASSERT_TRUE(session); // operation3 session still around
             }));
     }
 

--- a/pbft/test/pbft_audit_test.cpp
+++ b/pbft/test/pbft_audit_test.cpp
@@ -17,9 +17,9 @@ namespace bzn::test
 {
     TEST_F(pbft_test, test_local_commit_sends_audit_messages)
     {
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_audit, Eq(false)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_audit, Eq(false)), _))
                 .Times(AnyNumber());
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_audit, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_audit, Eq(true)), _))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         this->build_pbft();
@@ -47,7 +47,7 @@ namespace bzn::test
 
     TEST_F(pbft_test, primary_sends_primary_status)
     {
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_audit, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_audit, Eq(true)), _))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         this->build_pbft();
@@ -59,7 +59,7 @@ namespace bzn::test
 
     TEST_F(pbft_test, nonprimary_does_not_send_primary_status)
     {
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_audit, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_audit, Eq(true)), _))
                 .Times(Exactly(0));
 
         this->uuid = SECOND_NODE_UUID;

--- a/pbft/test/pbft_catchup_test.cpp
+++ b/pbft/test/pbft_catchup_test.cpp
@@ -108,7 +108,7 @@ namespace bzn
         this->build_pbft();
 
         // node shouldn't be sending any checkpoint messages right now
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_checkpoint, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_checkpoint, Eq(true)), _))
             .Times((Exactly(0)));
 
         auto nodes = TEST_PEER_LIST.begin();
@@ -121,7 +121,7 @@ namespace bzn
 
         // one more checkpoint message and the node should request state from a random node
         auto primary = this->pbft->get_primary();
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_get_state, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_get_state, Eq(true)), _))
             .Times((Exactly(1)));
 
         bzn::peer_address_t node(*nodes++);
@@ -140,7 +140,7 @@ namespace bzn
         }
 
         // since the node has this checkpoint it should NOT request state for it
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_get_state, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_get_state, Eq(true)), _))
             .Times((Exactly(0)));
         stabilize_checkpoint(100);
     }
@@ -171,7 +171,7 @@ namespace bzn
 
         // get the node to request state
         auto primary = this->pbft->get_primary();
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_get_state, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_get_state, Eq(true)), _))
             .Times((Exactly(1)));
 
         auto nodes = TEST_PEER_LIST.begin();
@@ -204,7 +204,7 @@ namespace bzn
 
         // get the node to request state
         auto primary = this->pbft->get_primary();
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_get_state, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_get_state, Eq(true)), _))
             .Times((Exactly(1)));
 
         auto nodes = TEST_PEER_LIST.begin();

--- a/pbft/test/pbft_checkpoint_tests.cpp
+++ b/pbft/test/pbft_checkpoint_tests.cpp
@@ -47,7 +47,7 @@ namespace bzn::test
 
     TEST_F(pbft_checkpoint_test, test_checkpoint_messages_sent_on_execute)
     {
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_checkpoint, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_checkpoint, Eq(true)), _))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         this->build_pbft();

--- a/pbft/test/pbft_join_leave_test.cpp
+++ b/pbft/test/pbft_join_leave_test.cpp
@@ -438,7 +438,7 @@ namespace bzn
         }
 
         // once second pbft gets f+1 viewchanges it will broadcast a viewchange message
-        EXPECT_CALL(*mock_node2, send_message(_, ResultOf(is_viewchange, Eq(true)), _))
+        EXPECT_CALL(*mock_node2, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_viewchange, Eq(true)), _))
             .Times((Exactly(TEST_PEER_LIST.size())))
             .WillRepeatedly(Invoke([&](auto, auto wmsg, bool /*close_session*/)
             {
@@ -449,7 +449,7 @@ namespace bzn
 
         auto newview_env = std::make_shared<bzn_envelope>();
         // second pbft should send a newview with the new configuration
-        EXPECT_CALL(*mock_node2, send_message(_, ResultOf(is_newview, Eq(true)), _))
+        EXPECT_CALL(*mock_node2, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_newview, Eq(true)), _))
             .Times((Exactly(TEST_PEER_LIST.size() + 1)))
             .WillRepeatedly(Invoke([&](auto, auto wmsg, bool /*close_session*/) {
                 pbft_msg msg;
@@ -511,7 +511,7 @@ namespace bzn
     TEST_F(pbft_join_leave_test, node_not_in_swarm_asks_to_join)
     {
         this->uuid = "somenode";
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_join, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_join, Eq(true)), _))
             .Times(Exactly(1))
             .WillOnce(Invoke([&](auto, auto, bool /*close_session*/)
             {
@@ -526,7 +526,7 @@ namespace bzn
 
     TEST_F(pbft_join_leave_test, node_in_swarm_doesnt_ask_to_join)
     {
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_join, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_join, Eq(true)), _))
             .Times(Exactly(0));
         this->build_pbft();
     }
@@ -552,7 +552,7 @@ namespace bzn
                     if (p.uuid == TEST_NODE_UUID)
                     {
                         EXPECT_CALL(*(mock_node),
-                            send_message(_, ResultOf(test::is_prepare, Eq(true)), _))
+                            send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_prepare, Eq(true)), _))
                             .Times(Exactly(TEST_PEER_LIST.size()));
 
                         // reflect the pre-prepare back

--- a/pbft/test/pbft_newview_test.cpp
+++ b/pbft/test/pbft_newview_test.cpp
@@ -81,7 +81,7 @@ namespace bzn
         this->run_transaction_through_primary_times(2, current_sequence);
 
         bzn_envelope viewchange_envelope;
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(test::is_viewchange, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true)), _))
                 .WillRepeatedly(Invoke([&](const auto & /*endpoint*/, const auto& viewchange_env, bool /*close_session*/) {viewchange_envelope = *viewchange_env;}));
         this->pbft->handle_failure();
 

--- a/pbft/test/pbft_proto_test.cpp
+++ b/pbft/test/pbft_proto_test.cpp
@@ -31,7 +31,7 @@ namespace bzn
     {
         // after request is sent, SUT will send out pre-prepares to all nodes
         auto operation = std::shared_ptr<pbft_operation>();
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_preprepare, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true)), _))
             .Times(Exactly(TEST_PEER_LIST.size()))
             .WillRepeatedly(Invoke([&](auto, auto wmsg, bool /*close_session*/)
             {
@@ -68,7 +68,7 @@ namespace bzn
     pbft_proto_test::send_preprepare(uint64_t sequence, const bzn_envelope& request)
     {
         // after preprepare is sent, SUT will send out prepares to all nodes
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_prepare, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_prepare, Eq(true)), _))
             .Times(Exactly(TEST_PEER_LIST.size()));
 
         auto peer = *(TEST_PEER_LIST.begin());
@@ -88,7 +88,7 @@ namespace bzn
     pbft_proto_test::send_prepares(uint64_t sequence, const bzn::hash_t& request_hash)
     {
         // after prepares are sent, SUT will send out commits to all nodes
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_commit, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_commit, Eq(true)), _))
             .Times(Exactly(TEST_PEER_LIST.size()));
 
         for (const auto& peer : TEST_PEER_LIST)
@@ -139,7 +139,7 @@ namespace bzn
             }));
 
         // after enough commits are sent, SUT will send out checkpoint message to all nodes
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_checkpoint, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_checkpoint, Eq(true)), _))
             .Times(Exactly(TEST_PEER_LIST.size()));
     }
 

--- a/pbft/test/pbft_test.cpp
+++ b/pbft/test/pbft_test.cpp
@@ -34,7 +34,7 @@ namespace bzn::test
     TEST_F(pbft_test, test_requests_fire_preprepare)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_preprepare, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_preprepare, Eq(true)), _))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         pbft->handle_database_message(this->request_msg, this->mock_session);
@@ -42,7 +42,7 @@ namespace bzn::test
 
     TEST_F(pbft_test, test_forwarded_to_primary_when_not_primary)
     {
-        EXPECT_CALL(*mock_node, send_message(_, A<std::shared_ptr<bzn_envelope>>(), _)).Times(1).WillRepeatedly(Invoke(
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), A<std::shared_ptr<bzn_envelope>>(), _)).Times(1).WillRepeatedly(Invoke(
                 [&](auto ep, auto msg, bool /*close_session*/)
                 {
                     EXPECT_EQ(ep, make_endpoint(this->pbft->get_primary()));
@@ -71,7 +71,7 @@ namespace bzn::test
     TEST_F(pbft_test, test_different_requests_get_different_sequences)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(_, _, _)).WillRepeatedly(Invoke(save_sequences));
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), _, _)).WillRepeatedly(Invoke(save_sequences));
 
         database_msg req, req2;
         req.mutable_header()->set_nonce(5);
@@ -86,7 +86,7 @@ namespace bzn::test
     TEST_F(pbft_test, test_preprepare_triggers_prepare)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_prepare, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true)), _))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         this->pbft->handle_message(this->preprepare_msg, default_original_msg);
@@ -96,7 +96,7 @@ namespace bzn::test
     {
         this->build_pbft();
         std::shared_ptr<bzn_envelope> wrapped_msg;
-        EXPECT_CALL(*mock_node, send_message(_, _, _)).WillRepeatedly(SaveArg<1>(&wrapped_msg));
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), _, _)).WillRepeatedly(SaveArg<1>(&wrapped_msg));
 
         this->pbft->handle_message(this->preprepare_msg, default_original_msg);
 
@@ -110,7 +110,7 @@ namespace bzn::test
     TEST_F(pbft_test, test_wrong_view_preprepare_rejected)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(_, _, _)).Times(Exactly(0));
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), _, _)).Times(Exactly(0));
 
         pbft_msg preprepare2(this->preprepare_msg);
         preprepare2.set_view(6);
@@ -121,7 +121,7 @@ namespace bzn::test
     TEST_F(pbft_test, test_no_duplicate_prepares_same_sequence_number)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(_, _, _)).Times(Exactly(TEST_PEER_LIST.size()));
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), _, _)).Times(Exactly(TEST_PEER_LIST.size()));
 
         pbft_msg preprepare2(this->preprepare_msg);
         preprepare2.set_request_hash("some other hash");
@@ -133,9 +133,9 @@ namespace bzn::test
     TEST_F(pbft_test, test_commit_messages_sent)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_prepare, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true)), _))
                 .Times(Exactly(TEST_PEER_LIST.size()));
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_commit, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_commit, Eq(true)), _))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         this->pbft->handle_message(this->preprepare_msg, default_original_msg);
@@ -202,7 +202,7 @@ namespace bzn::test
     TEST_F(pbft_test, messages_after_high_water_mark_dropped)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_prepare, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true)), _))
                 .Times(Exactly(0));
 
         this->preprepare_msg.set_sequence(pbft->get_high_water_mark() + 1);
@@ -212,7 +212,7 @@ namespace bzn::test
     TEST_F(pbft_test, messages_before_low_water_mark_dropped)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(is_prepare, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true)), _))
                 .Times(Exactly(0));
 
         this->preprepare_msg.set_sequence(this->pbft->get_low_water_mark());

--- a/pbft/test/pbft_timestamp_test.cpp
+++ b/pbft/test/pbft_timestamp_test.cpp
@@ -39,14 +39,14 @@ namespace bzn
         request->set_sender(TEST_NODE_UUID);
 
         // the first time we should get pre-prepare messages
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_preprepare, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true)), _))
             .Times(Exactly(TEST_PEER_LIST.size()));
         this->handle_request(*request);
 
         auto request2 = new bzn_envelope(*request);
 
         // this time no pre-prepare should be issued
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_preprepare, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true)), _))
             .Times(Exactly(0));
         this->handle_request(*request2);
     }
@@ -69,7 +69,7 @@ namespace bzn
         request->set_sender(TEST_NODE_UUID);
 
         // we should get pre-prepare messages
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_preprepare, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true)), _))
             .Times(Exactly(TEST_PEER_LIST.size()));
         this->handle_request(*request);
 
@@ -79,7 +79,7 @@ namespace bzn
         request2->set_timestamp(request2->timestamp() + 1);
 
         // again we should get pre-prepare messages
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_preprepare, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true)), _))
             .Times(Exactly(TEST_PEER_LIST.size()));
         this->handle_request(*request2);
 
@@ -95,7 +95,7 @@ namespace bzn
         request3->set_database_msg(dmsg3->SerializeAsString());
 
         // again we should get pre-prepare messages
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_preprepare, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true)), _))
             .Times(Exactly(TEST_PEER_LIST.size()));
         this->handle_request(*request3);
     }
@@ -118,7 +118,7 @@ namespace bzn
         request->set_sender(TEST_NODE_UUID);
 
         // we should get pre-prepare messages
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_preprepare, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true)), _))
             .Times(Exactly(TEST_PEER_LIST.size()));
         this->handle_request(*request);
 
@@ -127,7 +127,7 @@ namespace bzn
         request2->set_sender(SECOND_NODE_UUID);
 
         // again we should get pre-prepare messages
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_preprepare, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true)), _))
             .Times(Exactly(TEST_PEER_LIST.size()));
         this->handle_request(*request2);
     }
@@ -149,7 +149,7 @@ namespace bzn
         request->set_sender(TEST_NODE_UUID);
 
         // we should NOT get pre-prepare messages since this is an old request
-        EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_preprepare, Eq(true)), _))
+        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true)), _))
             .Times(Exactly(0));
         this->handle_request(*request);
     }

--- a/pbft/test/pbft_viewchange_test.cpp
+++ b/pbft/test/pbft_viewchange_test.cpp
@@ -162,7 +162,7 @@ namespace bzn
 
         this->run_transaction_through_primary_times(2, current_sequence);
 
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(test::is_viewchange, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true)), _))
                 .WillRepeatedly(Invoke(
                         [&](const auto & /*endpoint*/, const auto &viewchange_env, bool /*close_session*/)
                         {
@@ -206,7 +206,7 @@ namespace bzn
 
         this->run_transaction_through_primary_times(2, current_sequence);
 
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(test::is_viewchange, Eq(true)), _))
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true)), _))
                 .WillRepeatedly(Invoke([&](const auto & /*endpoint*/, const auto viewchange_env, bool /*close_session*/)
                 {
                     EXPECT_EQ(this->pbft->get_uuid(), viewchange_env->sender());
@@ -397,7 +397,7 @@ namespace bzn
                                            {
                                                 if (p.uuid == TEST_NODE_UUID)
                                                {
-                                                   EXPECT_CALL(*this->mock_node, send_message(_, ResultOf(test::is_prepare, Eq(true)), _))
+                                                   EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_prepare, Eq(true)), _))
                                                            .Times(Exactly(2 * TEST_PEER_LIST.size()));
                                                    pbft_msg msg;
                                                    ASSERT_TRUE(msg.ParseFromString(wmsg->pbft()));
@@ -406,7 +406,7 @@ namespace bzn
                                            }));
         }
 
-        EXPECT_CALL(*mock_node2, send_message(_, ResultOf(test::is_viewchange, Eq(true)), _))
+        EXPECT_CALL(*mock_node2, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true)), _))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         // get sut1 to generate viewchange message
@@ -428,7 +428,7 @@ namespace bzn
 
         EXPECT_CALL(*mock_crypto, hash(An<const bzn_envelope&>())).WillRepeatedly(Invoke([&](const bzn_envelope& envelope)
             {return envelope.sender() + "_" + std::to_string(current_sequence) + "_" + std::to_string(envelope.timestamp());}));
-        EXPECT_CALL(*mock_node, send_message(_, ResultOf(test::is_viewchange, Eq(true)), _)).WillRepeatedly(Invoke([&](const auto & /*endpoint*/, const auto &viewchange_env, bool /*close_session*/)
+        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true)), _)).WillRepeatedly(Invoke([&](const auto & /*endpoint*/, const auto &viewchange_env, bool /*close_session*/)
             { original_message = *viewchange_env; }));
 
         this->run_transaction_through_primary_times(1, current_sequence);

--- a/proto/database.proto
+++ b/proto/database.proto
@@ -54,6 +54,7 @@ message database_header
 {
     string db_uuid = 1;
     uint64 nonce = 2 [jstype = JS_STRING];
+    bytes point_of_contact = 3;
 }
 
 message database_create

--- a/raft/test/CMakeLists.txt
+++ b/raft/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(test_srcs raft_test.cpp raft_log_test.cpp raft_add_peers_test.cpp)
-set(test_libs raft storage bootstrap proto pbft ${Protobuf_LIBRARIES})
+set(test_libs raft storage bootstrap proto pbft pbft_operations ${Protobuf_LIBRARIES})
 
 add_gmock_test(raft)

--- a/raft/test/CMakeLists.txt
+++ b/raft/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(test_srcs raft_test.cpp raft_log_test.cpp raft_add_peers_test.cpp)
-set(test_libs raft storage bootstrap proto ${Protobuf_LIBRARIES})
+set(test_libs raft storage bootstrap proto pbft ${Protobuf_LIBRARIES})
 
 add_gmock_test(raft)

--- a/storage/test/CMakeLists.txt
+++ b/storage/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(test_srcs storage_test.cpp)
 set(test_libs storage node)
 set(test_deps rocksdb)
-set(test_link ${ROCKSDB_LIBRARIES})
+set(test_link pbft pbft_operations proto ${Protobuf_LIBRARIES} ${ROCKSDB_LIBRARIES})
 
 add_gmock_test(storage)

--- a/utils/crypto.cpp
+++ b/utils/crypto.cpp
@@ -368,7 +368,7 @@ namespace bzn::utils::crypto
         long len;
 
         ::FILE* fp = fopen(filename.c_str(), "r");
-        if( !fp)
+        if (!fp)
         {
             throw std::runtime_error("Failed to read pem file: " + filename);
         }


### PR DESCRIPTION
This is the first step in the final goal of KEP-981. I've added the functionality to have crud send result messages back to a node specified in the database message header, via the point_of_contact argument.

Session still works, but it can be easily removed when that refactor is necessary.