### PR TITLE
KEP-1092: Integration fixes for signature collation

### DIFF
--- a/crud/crud.cpp
+++ b/crud/crud.cpp
@@ -100,12 +100,10 @@ crud::send_response(const database_msg& request, const bzn::storage_result resul
 
     bzn_envelope env;
     env.set_database_response(response.SerializeAsString());
-    env.set_sender("placeholder for daemon's uuid"); // TODO
-    // TODO: crypto
 
     if (session)
     {
-        session->send_message(std::make_shared<std::string>(env.SerializeAsString()));
+        session->send_signed_message(std::make_shared<bzn_envelope>(env));
     }
     else
     {
@@ -116,7 +114,7 @@ crud::send_response(const database_msg& request, const bzn::storage_result resul
     {
         try
         {
-            this->node->send_message(response.header().point_of_contact(), std::make_shared<bzn_envelope>(env));
+            this->node->send_signed_message(response.header().point_of_contact(), std::make_shared<bzn_envelope>(env));
         }
         catch(const std::runtime_error& err)
         {

--- a/crud/test/crud_test.cpp
+++ b/crud/test/crud_test.cpp
@@ -46,22 +46,22 @@ namespace
 
                     if (db_uuid)
                     {
-                        EXPECT_EQ(resp.header().db_uuid(), db_uuid.value());
+                        EXPECT_EQ(resp.header().db_uuid(), *db_uuid);
                     }
 
                     if (nonce)
                     {
-                        EXPECT_EQ(resp.header().nonce(), nonce.value());
+                        EXPECT_EQ(resp.header().nonce(), *nonce);
                     }
 
                     if (response_case)
                     {
-                        EXPECT_EQ(resp.response_case(), response_case.value());
+                        EXPECT_EQ(resp.response_case(), *response_case);
                     }
 
                     if (error_msg)
                     {
-                        EXPECT_EQ(resp.error().message(), error_msg.value());
+                        EXPECT_EQ(resp.error().message(), *error_msg);
                     }
 
                     additional_checks(resp);

--- a/crud/test/crud_test.cpp
+++ b/crud/test/crud_test.cpp
@@ -29,6 +29,44 @@ namespace
         bzn_envelope intermediate;
         return intermediate.ParseFromString(source) && target.ParseFromString(intermediate.database_response());
     }
+
+    void expect_signed_response(const std::shared_ptr<bzn::Mocksession_base>& session,
+            std::optional<bzn::uuid_t> db_uuid = std::nullopt,
+            std::optional<uint64_t> nonce = std::nullopt,
+            std::optional<database_response::ResponseCase> response_case = std::nullopt,
+            std::optional<std::string> error_msg = std::nullopt,
+            std::function<void(const database_response&)> additional_checks = [](auto){})
+    {
+        EXPECT_CALL(*session, send_signed_message(_)).WillOnce(Invoke(
+                [=](std::shared_ptr<bzn_envelope> env)
+                {
+                    EXPECT_EQ(env->payload_case(), bzn_envelope::kDatabaseResponse);
+                    database_response resp;
+                    resp.ParseFromString(env->database_response());
+
+                    if (db_uuid)
+                    {
+                        EXPECT_EQ(resp.header().db_uuid(), db_uuid.value());
+                    }
+
+                    if (nonce)
+                    {
+                        EXPECT_EQ(resp.header().nonce(), nonce.value());
+                    }
+
+                    if (response_case)
+                    {
+                        EXPECT_EQ(resp.response_case(), response_case.value());
+                    }
+
+                    if (error_msg)
+                    {
+                        EXPECT_EQ(resp.error().message(), error_msg.value());
+                    }
+
+                    additional_checks(resp);
+                }));
+    }
 }
 
 
@@ -48,15 +86,7 @@ TEST(crud, test_that_create_sends_proper_response)
     // add key...
     auto session = std::make_shared<bzn::Mocksession_base>();
 
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.error().message(), bzn::storage_result_msg.at(bzn::storage_result::db_not_found));
-        }));
+    expect_signed_response(session, "uuid", 123, std::nullopt, bzn::storage_result_msg.at(bzn::storage_result::db_not_found));
 
     crud.handle_request("caller_id", msg, session);
 
@@ -64,15 +94,7 @@ TEST(crud, test_that_create_sends_proper_response)
     msg.release_create();
     msg.mutable_create_db();
 
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
-        }));
+    expect_signed_response(session, "uuid", 123, database_response::RESPONSE_NOT_SET);
 
     crud.handle_request("caller_id", msg, session);
 
@@ -83,59 +105,24 @@ TEST(crud, test_that_create_sends_proper_response)
 
     EXPECT_CALL(*mock_subscription_manager, inspect_commit(_));
 
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
-        }));
+    expect_signed_response(session, "uuid", 123, database_response::RESPONSE_NOT_SET);
 
     crud.handle_request("caller_id", msg, session);
 
     // fail to create same key...
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kError);
-            ASSERT_EQ(resp.error().message(), bzn::storage_result_msg.at(bzn::storage_result::exists));
-        }));
+    expect_signed_response(session, "uuid", 123, database_response::kError, bzn::storage_result_msg.at(bzn::storage_result::exists));
 
     crud.handle_request("caller_id", msg, session);
 
     // fail because key is too big...
     msg.mutable_create()->set_key(std::string(bzn::MAX_KEY_SIZE+1,'*'));
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kError);
-            ASSERT_EQ(resp.error().message(), bzn::storage_result_msg.at(bzn::storage_result::key_too_large));
-        }));
+    expect_signed_response(session, "uuid", 123, database_response::kError, bzn::storage_result_msg.at(bzn::storage_result::key_too_large));
 
     crud.handle_request("caller_id", msg, session);
 
     // fail because value is too big...
     msg.mutable_create()->set_value(std::string(bzn::MAX_VALUE_SIZE+1,'*'));
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kError);
-            ASSERT_EQ(resp.error().message(), bzn::storage_result_msg.at(bzn::storage_result::value_too_large));
-        }));
+    expect_signed_response(session, "uuid", uint64_t(123), database_response::kError, bzn::storage_result_msg.at(bzn::storage_result::value_too_large));
 
     crud.handle_request("caller_id", msg, session);
 }
@@ -158,7 +145,7 @@ TEST(crud, test_that_point_of_contact_create_sends_proper_response)
     msg.mutable_create()->set_value("value");
 
     // add key...
-    EXPECT_CALL(*mock_node, send_message("point_of_contact",_)).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact",_)).WillOnce(Invoke(
             [&](const bzn::uuid_t& , auto msg)
             {
                 database_response resp;
@@ -174,8 +161,8 @@ TEST(crud, test_that_point_of_contact_create_sends_proper_response)
     msg.release_create();
     msg.mutable_create_db();
 
-    // virtual void send_message(const bzn::uuid_t& , std::shared_ptr<bzn_envelope> msg, bool close_session) = 0;
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", _)).WillOnce(Invoke(
+    // virtual void send_signed_message(const bzn::uuid_t& , std::shared_ptr<bzn_envelope> msg, bool close_session) = 0;
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", _)).WillOnce(Invoke(
             [&](const auto& , auto msg)
             {
                 database_response resp;
@@ -194,7 +181,7 @@ TEST(crud, test_that_point_of_contact_create_sends_proper_response)
 
     EXPECT_CALL(*mock_subscription_manager, inspect_commit(_));
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", _)).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", _)).WillOnce(Invoke(
             [&](const auto& , auto msg)
             {
                 database_response resp;
@@ -207,7 +194,7 @@ TEST(crud, test_that_point_of_contact_create_sends_proper_response)
     crud.handle_request("caller_id", msg, nullptr);
 
     // fail to create same key...
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", _)).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", _)).WillOnce(Invoke(
             [&](const auto&, auto msg)
             {
                 database_response resp;
@@ -223,7 +210,7 @@ TEST(crud, test_that_point_of_contact_create_sends_proper_response)
 
     // fail because key is too big...
     msg.mutable_create()->set_key(std::string(bzn::MAX_KEY_SIZE+1,'*'));
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", _)).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", _)).WillOnce(Invoke(
         [&](const auto&, auto msg)
         {
             database_response resp;
@@ -238,7 +225,7 @@ TEST(crud, test_that_point_of_contact_create_sends_proper_response)
 
     // fail because value is too big...
     msg.mutable_create()->set_value(std::string(bzn::MAX_VALUE_SIZE+1,'*'));
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", _)).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", _)).WillOnce(Invoke(
         [&](const auto&, auto msg)
         {
             database_response resp;
@@ -277,7 +264,7 @@ TEST(crud, test_that_read_sends_proper_response)
 
     EXPECT_CALL(*mock_subscription_manager, inspect_commit(_));
 
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>()));
+    expect_signed_response(session);
     crud.handle_request("caller_id", msg, session);
 
     // clear msg...
@@ -286,66 +273,38 @@ TEST(crud, test_that_read_sends_proper_response)
 
     // read key...
     msg.mutable_read()->set_key("key");
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kRead);
-            ASSERT_EQ(resp.read().key(), "key");
-            ASSERT_EQ(resp.read().value(), "value");
-        }));
+    expect_signed_response(session, "uuid", uint64_t(123), database_response::kRead, std::nullopt,
+            [](const auto& resp)
+            {
+                ASSERT_EQ(resp.read().key(), "key");
+                ASSERT_EQ(resp.read().value(), "value");
+            });
 
     crud.handle_request("caller_id", msg, session);
 
     // quick read key...
     msg.release_read();
     msg.mutable_quick_read()->set_key("key");
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kRead);
-            ASSERT_EQ(resp.read().key(), "key");
-            ASSERT_EQ(resp.read().value(), "value");
-        }));
+    expect_signed_response(session, "uuid", uint64_t(123), database_response::kRead, std::nullopt,
+            [](const auto& resp)
+            {
+                ASSERT_EQ(resp.read().key(), "key");
+                ASSERT_EQ(resp.read().value(), "value");
+            });
 
     crud.handle_request("caller_id", msg, session);
 
     // read invalid key...
     msg.release_quick_read();
     msg.mutable_read()->set_key("invalid-key");
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kError);
-            ASSERT_EQ(resp.error().message(), bzn::storage_result_msg.at(bzn::storage_result::not_found));
-        }));
+    expect_signed_response(session, "uuid", uint64_t(123), database_response::kError, bzn::storage_result_msg.at(bzn::storage_result::not_found));
 
     crud.handle_request("caller_id", msg, session);
 
     // quick read invalid key...
     msg.release_read();
     msg.mutable_quick_read()->set_key("invalid-key");
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kError);
-            ASSERT_EQ(resp.error().message(), bzn::storage_result_msg.at(bzn::storage_result::not_found));
-        }));
+    expect_signed_response(session, "uuid", uint64_t(123), database_response::kError, bzn::storage_result_msg.at(bzn::storage_result::not_found));
 
     crud.handle_request("caller_id", msg, session);
 
@@ -378,7 +337,7 @@ TEST(crud, test_that_point_of_contact_read_sends_proper_response)
     // add key...
     EXPECT_CALL(*mock_subscription_manager, inspect_commit(_));
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
     crud.handle_request("caller_id", msg, nullptr);
 
     // clear msg...
@@ -388,7 +347,7 @@ TEST(crud, test_that_point_of_contact_read_sends_proper_response)
     // read key...
     msg.mutable_read()->set_key("key");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
         [&](const auto&, auto msg)
         {
             database_response resp;
@@ -406,7 +365,7 @@ TEST(crud, test_that_point_of_contact_read_sends_proper_response)
     msg.release_read();
     msg.mutable_quick_read()->set_key("key");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", _)).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", _)).WillOnce(Invoke(
         [&](const auto&, auto msg)
         {
             database_response resp;
@@ -424,7 +383,7 @@ TEST(crud, test_that_point_of_contact_read_sends_proper_response)
     msg.release_quick_read();
     msg.mutable_read()->set_key("invalid-key");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
         [&](const auto&, auto msg)
         {
             database_response resp;
@@ -440,7 +399,7 @@ TEST(crud, test_that_point_of_contact_read_sends_proper_response)
     // quick read invalid key...
     msg.release_read();
     msg.mutable_quick_read()->set_key("invalid-key");
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
         [&](const auto&, auto msg)
         {
             database_response resp;
@@ -483,7 +442,7 @@ TEST(crud, test_that_update_sends_proper_response)
 
     EXPECT_CALL(*mock_subscription_manager, inspect_commit(_));
 
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>()));
+    expect_signed_response(session);
     crud.handle_request("caller_id", msg, session);
 
     // clear msg...
@@ -495,15 +454,7 @@ TEST(crud, test_that_update_sends_proper_response)
 
     msg.mutable_update()->set_key("key");
     msg.mutable_update()->set_value("updated");
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
-        }));
+    expect_signed_response(session, "uuid", uint64_t(123), database_response::RESPONSE_NOT_SET);
 
     crud.handle_request("caller_id", msg, session);
 
@@ -513,17 +464,12 @@ TEST(crud, test_that_update_sends_proper_response)
 
     // read updated key...
     msg.mutable_read()->set_key("key");
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kRead);
-            ASSERT_EQ(resp.read().key(), "key");
-            ASSERT_EQ(resp.read().value(), "updated");
-        }));
+    expect_signed_response(session, "uuid", uint64_t(123), database_response::kRead, std::nullopt,
+            [](const auto& resp)
+            {
+                ASSERT_EQ(resp.read().key(), "key");
+                ASSERT_EQ(resp.read().value(), "updated");
+            });
 
     crud.handle_request("caller_id", msg, session);
 }
@@ -553,7 +499,7 @@ TEST(crud, test_that_point_of_contact_update_sends_proper_response)
     // add key...
     EXPECT_CALL(*mock_subscription_manager, inspect_commit(_));
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
     crud.handle_request("caller_id", msg, nullptr);
 
     // clear msg...
@@ -566,7 +512,7 @@ TEST(crud, test_that_point_of_contact_update_sends_proper_response)
     msg.mutable_update()->set_key("key");
     msg.mutable_update()->set_value("updated");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
         [&](const auto&, auto msg)
         {
             database_response resp;
@@ -585,7 +531,7 @@ TEST(crud, test_that_point_of_contact_update_sends_proper_response)
     // read updated key...
     msg.mutable_read()->set_key("key");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
         [&](const auto&, auto msg)
         {
             database_response resp;
@@ -625,7 +571,7 @@ TEST(crud, test_that_delete_sends_proper_response)
 
     EXPECT_CALL(*mock_subscription_manager, inspect_commit(_));
 
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>()));
+    expect_signed_response(session);
     crud.handle_request("caller_id", msg, session);
 
     // clear msg...
@@ -634,31 +580,14 @@ TEST(crud, test_that_delete_sends_proper_response)
 
     // delete key...
     msg.mutable_delete_()->set_key("key");
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
-        }));
+    expect_signed_response(session, "uuid", uint64_t(123), database_response::RESPONSE_NOT_SET);
 
     EXPECT_CALL(*mock_subscription_manager, inspect_commit(_));
 
     crud.handle_request("caller_id", msg, session);
 
     // delete invalid key...
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kError);
-            ASSERT_EQ(resp.error().message(), bzn::storage_result_msg.at(bzn::storage_result::not_found));
-        }));
+    expect_signed_response(session, "uuid", uint64_t(123), database_response::kError, bzn::storage_result_msg.at(bzn::storage_result::not_found));
 
     crud.handle_request("caller_id", msg, session);
 }
@@ -688,7 +617,7 @@ TEST(crud, test_that_point_of_contact_delete_sends_proper_response)
     // add key...
     EXPECT_CALL(*mock_subscription_manager, inspect_commit(_));
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
     crud.handle_request("caller_id", msg, nullptr);
 
     // clear msg...
@@ -698,7 +627,7 @@ TEST(crud, test_that_point_of_contact_delete_sends_proper_response)
     // delete key...
     msg.mutable_delete_()->set_key("key");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
         [&](const auto&, auto msg)
         {
             database_response resp;
@@ -713,7 +642,7 @@ TEST(crud, test_that_point_of_contact_delete_sends_proper_response)
     crud.handle_request("caller_id", msg, nullptr);
 
     // delete invalid key...
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
         [&](const auto&, auto msg)
         {
             database_response resp;
@@ -748,7 +677,7 @@ TEST(crud, test_that_has_sends_proper_response)
     // add key...
     auto session = std::make_shared<bzn::Mocksession_base>();
 
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>()));
+    expect_signed_response(session);
     crud.handle_request("caller_id", msg, session);
 
     // clear msg...
@@ -757,33 +686,23 @@ TEST(crud, test_that_has_sends_proper_response)
 
     // valid key...
     msg.mutable_has()->set_key("key");
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kHas);
-            ASSERT_EQ(resp.has().key(), "key");
-            ASSERT_TRUE(resp.has().has());
-        }));
+    expect_signed_response(session, "uuid", uint64_t(123), database_response::kHas, std::nullopt,
+            [](const auto& resp)
+            {
+                ASSERT_EQ(resp.has().key(), "key");
+                ASSERT_TRUE(resp.has().has());
+            });
 
     crud.handle_request("caller_id", msg, session);
 
     // invalid key...
     msg.mutable_has()->set_key("invalid-key");
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kHas);
-            ASSERT_EQ(resp.has().key(), "invalid-key");
-            ASSERT_FALSE(resp.has().has());
-        }));
+    expect_signed_response(session, "uuid", 123, database_response::kHas, std::nullopt,
+            [](const auto& resp)
+            {
+                ASSERT_EQ(resp.has().key(), "invalid-key");
+                ASSERT_FALSE(resp.has().has());
+            });
 
     crud.handle_request("caller_id", msg, session);
 
@@ -812,7 +731,7 @@ TEST(crud, test_that_point_of_contact_has_sends_proper_response)
     msg.mutable_create()->set_value("value");
 
     // add key...
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
     crud.handle_request("caller_id", msg, nullptr);
 
     // clear msg...
@@ -821,7 +740,7 @@ TEST(crud, test_that_point_of_contact_has_sends_proper_response)
 
     // valid key...
     msg.mutable_has()->set_key("key");
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [&](const auto&, auto msg)
             {
                 database_response resp;
@@ -838,7 +757,7 @@ TEST(crud, test_that_point_of_contact_has_sends_proper_response)
     // invalid key...
     msg.mutable_has()->set_key("invalid-key");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [&](const auto&, auto msg)
             {
                 database_response resp;
@@ -878,7 +797,7 @@ TEST(crud, test_that_keys_sends_proper_response)
     // add key...
     auto session = std::make_shared<bzn::Mocksession_base>();
 
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).Times(2);
+    EXPECT_CALL(*session, send_signed_message(_)).Times(2);
     crud.handle_request("caller_id", msg, session);
 
     // add another...
@@ -891,36 +810,26 @@ TEST(crud, test_that_keys_sends_proper_response)
 
     // get keys...
     msg.mutable_keys();
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kKeys);
-            ASSERT_EQ(resp.keys().keys().size(), int(2));
-            // keys are not returned in order created...
-            auto keys = resp.keys().keys();
-            std::sort(keys.begin(), keys.end());
-            ASSERT_EQ(keys[0], "key1");
-            ASSERT_EQ(keys[1], "key2");
-        }));
+    expect_signed_response(session, "uuid", uint64_t(123), database_response::kKeys, std::nullopt,
+            [](auto resp)
+            {
+                ASSERT_EQ(resp.keys().keys().size(), int(2));
+                // keys are not returned in order created...
+                auto keys = resp.keys().keys();
+                std::sort(keys.begin(), keys.end());
+                ASSERT_EQ(keys[0], "key1");
+                ASSERT_EQ(keys[1], "key2");
+            });
 
     crud.handle_request("caller_id", msg, session);
 
     // invalid uuid returns empty message...
     msg.mutable_header()->set_db_uuid("invalid-uuid");
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "invalid-uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kKeys);
-            ASSERT_EQ(resp.keys().keys().size(), int(0));
-        }));
+    expect_signed_response(session, "invalid-uuid", uint64_t(123), database_response::kKeys, std::nullopt,
+            [](auto resp)
+            {
+                ASSERT_EQ(resp.keys().keys().size(), int(0));
+            });
 
     crud.handle_request("caller_id", msg, session);
 
@@ -949,7 +858,7 @@ TEST(crud, test_that_point_of_contact_keys_sends_proper_response)
     msg.mutable_create()->set_value("value");
 
     // add key...
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).Times(2);
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).Times(2);
     crud.handle_request("caller_id", msg, nullptr);
 
     // add another...
@@ -963,7 +872,7 @@ TEST(crud, test_that_point_of_contact_keys_sends_proper_response)
     // get keys...
     msg.mutable_keys();
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [&](const auto&, auto msg)
             {
                 database_response resp;
@@ -984,7 +893,7 @@ TEST(crud, test_that_point_of_contact_keys_sends_proper_response)
     // invalid uuid returns empty message...
     msg.mutable_header()->set_db_uuid("invalid-uuid");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [&](const auto&, auto msg)
             {
                 database_response resp;
@@ -1023,7 +932,7 @@ TEST(crud, test_that_size_sends_proper_response)
     // add key...
     auto session = std::make_shared<bzn::Mocksession_base>();
 
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>()));
+    expect_signed_response(session);
     crud.handle_request("caller_id", msg, session);
 
     // clear msg...
@@ -1032,33 +941,23 @@ TEST(crud, test_that_size_sends_proper_response)
 
     // get size...
     msg.mutable_size();
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kSize);
-            ASSERT_EQ(resp.size().bytes(), int32_t(5));
-            ASSERT_EQ(resp.size().keys(), int32_t(1));
-        }));
+    expect_signed_response(session, "uuid", uint64_t(123), database_response::kSize, std::nullopt,
+            [](auto resp)
+            {
+                ASSERT_EQ(resp.size().bytes(), int32_t(5));
+                ASSERT_EQ(resp.size().keys(), int32_t(1));
+            });
 
     crud.handle_request("caller_id", msg, session);
 
     // invalid uuid returns zero...
     msg.mutable_header()->set_db_uuid("invalid-uuid");
-    EXPECT_CALL(*session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [&](auto msg)
-        {
-            database_response resp;
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "invalid-uuid");
-            ASSERT_EQ(resp.header().nonce(), uint64_t(123));
-            ASSERT_EQ(resp.response_case(), database_response::kSize);
-            ASSERT_EQ(resp.size().bytes(), int32_t(0));
-            ASSERT_EQ(resp.size().keys(), int32_t(0));
-        }));
+    expect_signed_response(session, "invalid-uuid", uint64_t(123), database_response::kSize, std::nullopt,
+            [](auto resp)
+            {
+                ASSERT_EQ(resp.size().bytes(), int32_t(0));
+                ASSERT_EQ(resp.size().keys(), int32_t(0));
+            });
 
     crud.handle_request("caller_id", msg, session);
 
@@ -1087,7 +986,7 @@ TEST(crud, test_that_point_of_contact_size_sends_proper_response)
     msg.mutable_create()->set_value("value");
 
     // add key...
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
     crud.handle_request("caller_id", msg, nullptr);
 
     // clear msg...
@@ -1097,7 +996,7 @@ TEST(crud, test_that_point_of_contact_size_sends_proper_response)
     // get size...
     msg.mutable_size();
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [&](const auto&, auto msg)
             {
                 database_response resp;
@@ -1114,7 +1013,7 @@ TEST(crud, test_that_point_of_contact_size_sends_proper_response)
     // invalid uuid returns zero...
     msg.mutable_header()->set_db_uuid("invalid-uuid");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [&](const auto&, auto msg)
             {
                 database_response resp;
@@ -1160,7 +1059,7 @@ TEST(crud, test_that_subscribe_request_calls_subscription_manager)
     EXPECT_CALL(*mock_subscription_manager, subscribe(msg.header().db_uuid(), msg.subscribe().key(),
         msg.header().nonce(), _, _));
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>()));
+    expect_signed_response(mock_session);
 
     crud.handle_request("caller_id", msg, mock_session);
 }
@@ -1192,7 +1091,7 @@ TEST(crud, test_that_unsubscribe_request_calls_subscription_manager)
     EXPECT_CALL(*mock_subscription_manager, unsubscribe(msg.header().db_uuid(), msg.unsubscribe().key(),
         msg.unsubscribe().nonce(), _, _));
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>()));
+    expect_signed_response(mock_session);
 
     crud.handle_request("caller_id", msg, mock_session);
 }
@@ -1212,27 +1111,11 @@ TEST(crud, test_that_create_db_request_sends_proper_response)
 
     auto mock_session = std::make_shared<bzn::Mocksession_base>();
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
-        }));
+    expect_signed_response(mock_session, "uuid", std::nullopt, database_response::RESPONSE_NOT_SET);
 
     crud.handle_request("caller_id", msg, mock_session);
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.error().message(), bzn::storage_result_msg.at(bzn::storage_result::db_exists));
-        }));
+    expect_signed_response(mock_session, "uuid", std::nullopt, std::nullopt, bzn::storage_result_msg.at(bzn::storage_result::db_exists));
 
     // try to create it again...
     crud.handle_request("caller_id", msg, mock_session);
@@ -1254,7 +1137,7 @@ TEST(crud, test_that_point_of_contact_create_db_request_sends_proper_response)
 
     msg.mutable_create_db();
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;
@@ -1266,7 +1149,7 @@ TEST(crud, test_that_point_of_contact_create_db_request_sends_proper_response)
 
     crud.handle_request("caller_id", msg, nullptr);
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;
@@ -1303,32 +1186,23 @@ TEST(crud, test_that_has_db_request_sends_proper_response)
     msg.release_create_db();
     msg.mutable_has_db();
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.response_case(), database_response::kHasDb);
-            ASSERT_EQ(resp.has_db().uuid(), "uuid");
-            ASSERT_TRUE(resp.has_db().has());
-        }));
+    expect_signed_response(mock_session, "uuid", std::nullopt, database_response::kHasDb, std::nullopt,
+            [](auto resp)
+            {
+                ASSERT_TRUE(resp.has_db().has());
+            });
 
     crud.handle_request("caller_id", msg, mock_session);
 
     // request invalid db...
     msg.mutable_header()->set_db_uuid("invalid-uuid");
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.response_case(), database_response::kHasDb);
-            ASSERT_EQ(resp.has_db().uuid(), "invalid-uuid");
-            ASSERT_FALSE(resp.has_db().has());
-        }));
+    expect_signed_response(mock_session, std::nullopt, std::nullopt, database_response::kHasDb, std::nullopt,
+            [](auto resp)
+            {
+                ASSERT_FALSE(resp.has_db().has());
+                ASSERT_EQ(resp.has_db().uuid(), "invalid-uuid");
+            });
 
     crud.handle_request("caller_id", msg, mock_session);
 }
@@ -1356,7 +1230,7 @@ TEST(crud, test_that_point_of_contact_has_db_request_sends_proper_response)
     msg.release_create_db();
     msg.mutable_has_db();
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;
@@ -1372,7 +1246,7 @@ TEST(crud, test_that_point_of_contact_has_db_request_sends_proper_response)
     // request invalid db...
     msg.mutable_header()->set_db_uuid("invalid-uuid");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;
@@ -1401,15 +1275,7 @@ TEST(crud, test_that_delete_db_sends_proper_response)
 
     auto mock_session = std::make_shared<bzn::Mocksession_base>();
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.error().message(), bzn::storage_result_msg.at(bzn::storage_result::db_not_found));
-        }));
+    expect_signed_response(mock_session, "uuid", std::nullopt, std::nullopt, bzn::storage_result_msg.at(bzn::storage_result::db_not_found));
 
     crud.handle_request("caller_id", msg, mock_session);
 
@@ -1417,7 +1283,7 @@ TEST(crud, test_that_delete_db_sends_proper_response)
     msg.release_delete_db();
     msg.mutable_create_db();
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>()));
+    expect_signed_response(mock_session);
 
     crud.handle_request("caller_id", msg, mock_session);
 
@@ -1425,28 +1291,12 @@ TEST(crud, test_that_delete_db_sends_proper_response)
     msg.release_create_db();
     msg.mutable_delete_db();
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.error().message(), bzn::storage_result_msg.at(bzn::storage_result::access_denied));
-        }));
+    expect_signed_response(mock_session, "uuid", std::nullopt, std::nullopt, bzn::storage_result_msg.at(bzn::storage_result::access_denied));
 
     // non-owner caller...
     crud.handle_request("bad_caller_id", msg, mock_session);
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
-        }));
+    expect_signed_response(mock_session, "uuid", std::nullopt, database_response::RESPONSE_NOT_SET);
 
     crud.handle_request("caller_id", msg, mock_session);
 }
@@ -1466,7 +1316,7 @@ TEST(crud, test_that_point_of_contact_delete_db_sends_proper_response)
     msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_delete_db();
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;
@@ -1482,7 +1332,7 @@ TEST(crud, test_that_point_of_contact_delete_db_sends_proper_response)
     msg.release_delete_db();
     msg.mutable_create_db();
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
 
     crud.handle_request("caller_id", msg, nullptr);
 
@@ -1490,7 +1340,7 @@ TEST(crud, test_that_point_of_contact_delete_db_sends_proper_response)
     msg.release_create_db();
     msg.mutable_delete_db();
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;
@@ -1503,7 +1353,7 @@ TEST(crud, test_that_point_of_contact_delete_db_sends_proper_response)
     // non-owner caller...
     crud.handle_request("bad_caller_id", msg, nullptr);
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;
@@ -1547,7 +1397,7 @@ TEST(crud, test_that_writers_sends_proper_response)
 
     auto mock_session = std::make_shared<bzn::Mocksession_base>();
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>()));
+    expect_signed_response(mock_session);
 
     crud.handle_request("caller_id", msg, mock_session);
 
@@ -1556,17 +1406,12 @@ TEST(crud, test_that_writers_sends_proper_response)
     msg.mutable_writers();
 
     // only the owner should be set at this stage...
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.response_case(), database_response::kWriters);
-            ASSERT_EQ(resp.writers().owner(), "caller_id");
-            ASSERT_EQ(resp.writers().writers().size(), 0);
-        }));
+    expect_signed_response(mock_session, "uuid", std::nullopt, database_response::kWriters, std::nullopt,
+            [](auto resp)
+            {
+                ASSERT_EQ(resp.writers().owner(), "caller_id");
+                ASSERT_EQ(resp.writers().writers().size(), 0);
+            });
 
     crud.handle_request("caller_id", msg, mock_session);
 }
@@ -1586,7 +1431,7 @@ TEST(crud, test_that_point_of_contact_writers_sends_proper_response)
     msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create_db();
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
 
     crud.handle_request("caller_id", msg, nullptr);
 
@@ -1595,7 +1440,7 @@ TEST(crud, test_that_point_of_contact_writers_sends_proper_response)
     msg.mutable_writers();
 
     // only the owner should be set at this stage...
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;
@@ -1625,7 +1470,7 @@ TEST(crud, test_that_add_writers_sends_proper_response)
 
     auto mock_session = std::make_shared<bzn::Mocksession_base>();
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>()));
+    expect_signed_response(mock_session);
 
     crud.handle_request("caller_id", msg, mock_session);
 
@@ -1638,28 +1483,12 @@ TEST(crud, test_that_add_writers_sends_proper_response)
     msg.mutable_add_writers()->add_writers("client_1_key");
     msg.mutable_add_writers()->add_writers("client_2_key");
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
-        }));
+    expect_signed_response(mock_session, "uuid", std::nullopt, database_response::RESPONSE_NOT_SET);
 
     crud.handle_request("caller_id", msg, mock_session);
 
     // access test
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.error().message(), bzn::storage_result_msg.at(bzn::storage_result::access_denied));
-        }));
+    expect_signed_response(mock_session, "uuid", std::nullopt, std::nullopt, bzn::storage_result_msg.at(bzn::storage_result::access_denied));
 
     crud.handle_request("other_caller_id", msg, mock_session);
 
@@ -1668,19 +1497,14 @@ TEST(crud, test_that_add_writers_sends_proper_response)
     msg.mutable_writers();
 
     // only the owner should be set at this stage...
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.response_case(), database_response::kWriters);
-            ASSERT_EQ(resp.writers().owner(), "caller_id");
-            ASSERT_EQ(resp.writers().writers().size(), 2);
-            ASSERT_EQ(resp.writers().writers()[0], "client_1_key");
-            ASSERT_EQ(resp.writers().writers()[1], "client_2_key");
-        }));
+    expect_signed_response(mock_session, "uuid", std::nullopt, database_response::kWriters, std::nullopt,
+            [](auto resp)
+            {
+                ASSERT_EQ(resp.writers().owner(), "caller_id");
+                ASSERT_EQ(resp.writers().writers().size(), 2);
+                ASSERT_EQ(resp.writers().writers()[0], "client_1_key");
+                ASSERT_EQ(resp.writers().writers()[1], "client_2_key");
+            });
 
     crud.handle_request("caller_id", msg, mock_session);
 }
@@ -1700,7 +1524,7 @@ TEST(crud, test_that_point_of_contact_add_writers_sends_proper_response)
     msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create_db();
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
 
     crud.handle_request("caller_id", msg, nullptr);
 
@@ -1713,7 +1537,7 @@ TEST(crud, test_that_point_of_contact_add_writers_sends_proper_response)
     msg.mutable_add_writers()->add_writers("client_1_key");
     msg.mutable_add_writers()->add_writers("client_2_key");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;
@@ -1726,7 +1550,7 @@ TEST(crud, test_that_point_of_contact_add_writers_sends_proper_response)
     crud.handle_request("caller_id", msg, nullptr);
 
     // access test
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;
@@ -1743,7 +1567,7 @@ TEST(crud, test_that_point_of_contact_add_writers_sends_proper_response)
     msg.mutable_writers();
 
     // only the owner should be set at this stage...
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;
@@ -1775,7 +1599,7 @@ TEST(crud, test_that_remove_writers_sends_proper_response)
 
     auto mock_session = std::make_shared<bzn::Mocksession_base>();
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>()));
+    expect_signed_response(mock_session);
 
     crud.handle_request("caller_id", msg, mock_session);
 
@@ -1785,7 +1609,7 @@ TEST(crud, test_that_remove_writers_sends_proper_response)
     msg.mutable_add_writers()->add_writers("client_1_key");
     msg.mutable_add_writers()->add_writers("client_2_key");
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>()));
+    expect_signed_response(mock_session);
 
     crud.handle_request("caller_id", msg, mock_session);
 
@@ -1793,28 +1617,12 @@ TEST(crud, test_that_remove_writers_sends_proper_response)
     msg.release_create_db();
     msg.mutable_remove_writers()->add_writers("client_2_key");
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.response_case(), database_response::RESPONSE_NOT_SET);
-        }));
+    expect_signed_response(mock_session, "uuid", std::nullopt, database_response::RESPONSE_NOT_SET);
 
     crud.handle_request("caller_id", msg, mock_session);
 
     // access test
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<std::string>>())).WillOnce(Invoke(
-        [](std::shared_ptr<bzn::encoded_message> msg)
-        {
-            database_response resp;
-
-            ASSERT_TRUE(parse_env_to_db_resp(resp, *msg));
-            ASSERT_EQ(resp.header().db_uuid(), "uuid");
-            ASSERT_EQ(resp.error().message(), bzn::storage_result_msg.at(bzn::storage_result::access_denied));
-        }));
+    expect_signed_response(mock_session, "uuid", std::nullopt, std::nullopt, bzn::storage_result_msg.at(bzn::storage_result::access_denied));
 
     crud.handle_request("other_caller_id", msg, mock_session);
 }
@@ -1834,7 +1642,7 @@ TEST(crud, test_that_point_of_contact_remove_writers_sends_proper_response)
     msg.mutable_header()->set_nonce(uint64_t(123));
     msg.mutable_create_db();
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
 
     crud.handle_request("caller_id", msg, nullptr);
 
@@ -1844,7 +1652,7 @@ TEST(crud, test_that_point_of_contact_remove_writers_sends_proper_response)
     msg.mutable_add_writers()->add_writers("client_1_key");
     msg.mutable_add_writers()->add_writers("client_2_key");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>()));
 
     crud.handle_request("caller_id", msg, nullptr);
 
@@ -1852,7 +1660,7 @@ TEST(crud, test_that_point_of_contact_remove_writers_sends_proper_response)
     msg.release_create_db();
     msg.mutable_remove_writers()->add_writers("client_2_key");
 
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;
@@ -1865,7 +1673,7 @@ TEST(crud, test_that_point_of_contact_remove_writers_sends_proper_response)
     crud.handle_request("caller_id", msg, nullptr);
 
     // access test
-    EXPECT_CALL(*mock_node, send_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
+    EXPECT_CALL(*mock_node, send_signed_message("point_of_contact", An<std::shared_ptr<bzn_envelope>>())).WillOnce(Invoke(
             [](const auto&, auto msg)
             {
                 database_response resp;

--- a/mocks/mock_node_base.hpp
+++ b/mocks/mock_node_base.hpp
@@ -28,9 +28,9 @@ class Mocknode_base : public node_base {
       bool(const bzn_envelope::PayloadCase msg_type, bzn::protobuf_handler message_handler));
   MOCK_METHOD1(start,
       void(std::shared_ptr<bzn::pbft_base> pbft));
-  MOCK_METHOD2(send_message,
+  MOCK_METHOD2(send_signed_message,
       void(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn_envelope> msg));
-  MOCK_METHOD2(send_message,
+  MOCK_METHOD2(send_signed_message,
       void(const bzn::uuid_t& uuid, std::shared_ptr<bzn_envelope> msg));
   MOCK_METHOD2(send_message_str,
       void(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::encoded_message> msg));

--- a/mocks/mock_session_base.hpp
+++ b/mocks/mock_session_base.hpp
@@ -25,6 +25,8 @@ namespace bzn {
     public:
         MOCK_METHOD1(send_message,
             void(std::shared_ptr<bzn::encoded_message> msg));
+        MOCK_METHOD1(send_signed_message,
+                void(std::shared_ptr<bzn_envelope> msg));
         MOCK_METHOD0(get_session_id,
             bzn::session_id());
         MOCK_METHOD0(close,

--- a/node/node.hpp
+++ b/node/node.hpp
@@ -42,11 +42,11 @@ namespace bzn
 
         void start(std::shared_ptr<bzn::pbft_base> pbft) override;
 
-        void send_message(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn_envelope> msg) override;
+        void send_signed_message(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn_envelope> msg) override;
 
         void send_message_str(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::encoded_message> msg) override;
 
-        void send_message(const bzn::uuid_t &uuid, std::shared_ptr<bzn_envelope> msg) override;
+        void send_signed_message(const bzn::uuid_t& uuid, std::shared_ptr<bzn_envelope> msg) override;
 
     private:
         FRIEND_TEST(node, test_that_registered_message_handler_is_invoked);
@@ -54,12 +54,12 @@ namespace bzn
 
         void do_accept();
 
-
         void priv_protobuf_handler(const bzn_envelope& msg, std::shared_ptr<bzn::session_base> session);
         void priv_session_shutdown_handler(const ep_key_t& ep_key);
 
         std::shared_ptr<bzn::pbft_base>               pbft;
 
+        std::shared_ptr<bzn::session_base> find_session(const boost::asio::ip::tcp::endpoint& ep);
         std::shared_ptr<bzn::session_base> open_session(const boost::asio::ip::tcp::endpoint& ep);
 
         ep_key_t key_from_ep(const boost::asio::ip::tcp::endpoint& ep);

--- a/node/node_base.hpp
+++ b/node/node_base.hpp
@@ -48,7 +48,7 @@ namespace bzn
          * @param ep            host to send the message to
          * @param msg           message to send
          */
-        virtual void send_message(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn_envelope> msg) = 0;
+        virtual void send_signed_message(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn_envelope> msg) = 0;
 
         /**
          * Convenience method to connect and send a message to a node. Will set sender and signature fields as appropriate.
@@ -57,7 +57,7 @@ namespace bzn
          */
         virtual void send_message_str(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::encoded_message> msg) = 0;
 
-        virtual void send_message(const bzn::uuid_t &uuid, std::shared_ptr<bzn_envelope> msg) = 0;
+        virtual void send_signed_message(const bzn::uuid_t& uuid, std::shared_ptr<bzn_envelope> msg) = 0;
     };
 
 } // bzn

--- a/node/node_base.hpp
+++ b/node/node_base.hpp
@@ -43,20 +43,26 @@ namespace bzn
         virtual void start(std::shared_ptr<bzn::pbft_base> pbft) = 0;
 
         /**
-         * Convenience method to connect and send a message to a node. Will appropriately populate the sender and
-         * signature fields, if not already set.
+         * Send a raw string message
+         * @param ep            host to send the message to
+         * @param msg           message to send
+         */
+        virtual void send_message_str(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::encoded_message> msg) = 0;
+
+        /**
+         * Send a message to a node identified by endpoint. If the sender field is empty or contains our uuid, the message will be
+         * signed before sending. If the sender field contains something else, an existing signature will be kept intact.
          * @param ep            host to send the message to
          * @param msg           message to send
          */
         virtual void send_signed_message(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn_envelope> msg) = 0;
 
         /**
-         * Convenience method to connect and send a message to a node. Will set sender and signature fields as appropriate.
-         * @param ep            host to send the message to
+         * Send a message to a node identified by uuid. If the sender field is empty or contains our uuid, the message will be
+         * signed before sending. If the sender field contains something else, an existing signature will be kept intact.
+         * @param uuid            host to send the message to
          * @param msg           message to send
          */
-        virtual void send_message_str(const boost::asio::ip::tcp::endpoint& ep, std::shared_ptr<bzn::encoded_message> msg) = 0;
-
         virtual void send_signed_message(const bzn::uuid_t& uuid, std::shared_ptr<bzn_envelope> msg) = 0;
     };
 

--- a/node/session.hpp
+++ b/node/session.hpp
@@ -40,11 +40,13 @@ namespace bzn
                 std::shared_ptr<bzn::chaos_base> chaos,
                 bzn::protobuf_handler proto_handler,
                 std::chrono::milliseconds ws_idle_timeout,
-                bzn::session_shutdown_handler shutdown_handler);
+                bzn::session_shutdown_handler shutdown_handler,
+                std::shared_ptr<bzn::crypto_base> crypto);
 
         ~session();
 
         void send_message(std::shared_ptr<bzn::encoded_message> msg) override;
+        void send_signed_message(std::shared_ptr<bzn_envelope> msg) override;
 
         void close() override;
 
@@ -84,6 +86,8 @@ namespace bzn
         std::atomic<bool> activity = false;
 
         boost::asio::mutable_buffers_1 write_buffer;
+
+        std::shared_ptr<bzn::crypto_base> crypto;
     };
 
 } // blz

--- a/node/session_base.hpp
+++ b/node/session_base.hpp
@@ -33,10 +33,17 @@ namespace bzn
         virtual ~session_base() = default;
 
         /**
-         * Send a message to the connected node
+         * Send a raw string to whatever's on the other end of this session
          * @param msg message
          */
         virtual void send_message(std::shared_ptr<bzn::encoded_message> msg) = 0;
+
+        /**
+         * Send a message to whatever's on the other end of this session. If the sender field is empty or contains
+         * our uuid, the message will be signed before sending. If the sender field contains something else,
+         * an existing signature will be kept intact.
+         * @param msg           message to send
+         */
         virtual void send_signed_message(std::shared_ptr<bzn_envelope> msg) = 0;
 
         /**

--- a/node/session_base.hpp
+++ b/node/session_base.hpp
@@ -37,6 +37,7 @@ namespace bzn
          * @param msg message
          */
         virtual void send_message(std::shared_ptr<bzn::encoded_message> msg) = 0;
+        virtual void send_signed_message(std::shared_ptr<bzn_envelope> msg) = 0;
 
         /**
          * Perform an orderly shutdown of the websocket.

--- a/node/test/session_test.cpp
+++ b/node/test/session_test.cpp
@@ -66,7 +66,7 @@ public:
 
     session_test2()
     {
-        session = std::make_shared<bzn::session>(mock.io_context, 0, TEST_ENDPOINT, this->mock_chaos, [&](auto, auto){this->handler_called++;}, TEST_TIMEOUT, [](){});
+        session = std::make_shared<bzn::session>(mock.io_context, 0, TEST_ENDPOINT, this->mock_chaos, [&](auto, auto){this->handler_called++;}, TEST_TIMEOUT, [](){}, nullptr);
     }
 
     void yield()
@@ -93,7 +93,7 @@ namespace bzn
 
         EXPECT_CALL(*mock_websocket_stream, async_read(_,_));
 
-        auto session = std::make_shared<bzn::session>(this->io_context, bzn::session_id(1), TEST_ENDPOINT, this->mock_chaos, [](auto, auto){}, TEST_TIMEOUT, [](){});
+        auto session = std::make_shared<bzn::session>(this->io_context, bzn::session_id(1), TEST_ENDPOINT, this->mock_chaos, [](auto, auto){}, TEST_TIMEOUT, [](){}, nullptr);
         session->accept(mock_websocket_stream);
         accept_handler(boost::system::error_code{});
 

--- a/pbft/pbft.cpp
+++ b/pbft/pbft.cpp
@@ -328,7 +328,8 @@ void
 pbft::forward_request_to_primary(const bzn_envelope& request_env)
 {
     LOG(info) << "Forwarding request to primary";
-    this->node->send_message(bzn::make_endpoint(this->get_primary()), std::make_shared<bzn_envelope>(request_env));
+    this->node
+        ->send_signed_message(bzn::make_endpoint(this->get_primary()), std::make_shared<bzn_envelope>(request_env));
 
     const bzn::hash_t req_hash = this->crypto->hash(request_env);
 
@@ -583,7 +584,7 @@ pbft::broadcast(const bzn_envelope& msg)
 
     for (const auto& peer : this->current_peers())
     {
-        this->node->send_message(make_endpoint(peer), msg_ptr);
+        this->node->send_signed_message(make_endpoint(peer), msg_ptr);
     }
 }
 
@@ -963,7 +964,7 @@ pbft::request_checkpoint_state(const checkpoint_t& cp)
     // TODO: fix the race condition here where receiving node may not have had time to
     //  stabilize its checkpoint yet.
     auto msg_ptr = std::make_shared<bzn_envelope>(this->wrap_message(msg));
-    this->node->send_message(make_endpoint(selected), msg_ptr);
+    this->node->send_signed_message(make_endpoint(selected), msg_ptr);
 }
 
 const peer_address_t&
@@ -1840,7 +1841,7 @@ pbft::join_swarm()
 
     LOG(info) << "Sending request to join swarm to node " << this->current_peers()[selected].uuid;
     auto msg_ptr = std::make_shared<bzn_envelope>(this->wrap_message(join_msg));
-    this->node->send_message(make_endpoint(this->current_peers()[selected]), msg_ptr);
+    this->node->send_signed_message(make_endpoint(this->current_peers()[selected]), msg_ptr);
 
     this->in_swarm = swarm_status::joining;
     this->join_retry_timer->expires_from_now(JOIN_RETRY_INTERVAL);

--- a/pbft/test/pbft_audit_test.cpp
+++ b/pbft/test/pbft_audit_test.cpp
@@ -17,9 +17,9 @@ namespace bzn::test
 {
     TEST_F(pbft_test, test_local_commit_sends_audit_messages)
     {
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_audit, Eq(false))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_audit, Eq(false))))
                 .Times(AnyNumber());
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_audit, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_audit, Eq(true))))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         this->build_pbft();
@@ -47,7 +47,7 @@ namespace bzn::test
 
     TEST_F(pbft_test, primary_sends_primary_status)
     {
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_audit, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_audit, Eq(true))))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         this->build_pbft();
@@ -59,7 +59,7 @@ namespace bzn::test
 
     TEST_F(pbft_test, nonprimary_does_not_send_primary_status)
     {
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_audit, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_audit, Eq(true))))
                 .Times(Exactly(0));
 
         this->uuid = SECOND_NODE_UUID;

--- a/pbft/test/pbft_catchup_test.cpp
+++ b/pbft/test/pbft_catchup_test.cpp
@@ -108,7 +108,7 @@ namespace bzn
         this->build_pbft();
 
         // node shouldn't be sending any checkpoint messages right now
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_checkpoint, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_checkpoint, Eq(true))))
             .Times((Exactly(0)));
 
         auto nodes = TEST_PEER_LIST.begin();
@@ -121,7 +121,7 @@ namespace bzn
 
         // one more checkpoint message and the node should request state from a random node
         auto primary = this->pbft->get_primary();
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_get_state, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_get_state, Eq(true))))
             .Times((Exactly(1)));
 
         bzn::peer_address_t node(*nodes++);
@@ -140,7 +140,7 @@ namespace bzn
         }
 
         // since the node has this checkpoint it should NOT request state for it
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_get_state, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_get_state, Eq(true))))
             .Times((Exactly(0)));
         stabilize_checkpoint(100);
     }
@@ -171,7 +171,7 @@ namespace bzn
 
         // get the node to request state
         auto primary = this->pbft->get_primary();
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_get_state, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_get_state, Eq(true))))
             .Times((Exactly(1)));
 
         auto nodes = TEST_PEER_LIST.begin();
@@ -204,7 +204,7 @@ namespace bzn
 
         // get the node to request state
         auto primary = this->pbft->get_primary();
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_get_state, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_get_state, Eq(true))))
             .Times((Exactly(1)));
 
         auto nodes = TEST_PEER_LIST.begin();

--- a/pbft/test/pbft_checkpoint_tests.cpp
+++ b/pbft/test/pbft_checkpoint_tests.cpp
@@ -47,7 +47,7 @@ namespace bzn::test
 
     TEST_F(pbft_checkpoint_test, test_checkpoint_messages_sent_on_execute)
     {
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_checkpoint, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_checkpoint, Eq(true))))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         this->build_pbft();

--- a/pbft/test/pbft_join_leave_test.cpp
+++ b/pbft/test/pbft_join_leave_test.cpp
@@ -108,7 +108,7 @@ namespace bzn
             for (auto const &p : TEST_PEER_LIST)
             {
                 EXPECT_CALL(*(mock_node),
-                    send_message(bzn::make_endpoint(p),
+                    send_signed_message(bzn::make_endpoint(p),
                         AllOf(message_has_correct_req_hash(expect_hash), message_has_correct_pbft_type(PBFT_MSG_PREPARE))))
                     .Times(Exactly(1));
             }
@@ -221,7 +221,7 @@ namespace bzn
         for (auto const &p : TEST_PEER_LIST)
         {
             EXPECT_CALL(*(this->mock_node),
-                send_message(bzn::make_endpoint(p),
+                send_signed_message(bzn::make_endpoint(p),
                     AllOf(message_has_req_with_correct_type(bzn_envelope::kPbftInternalRequest),
                         message_has_correct_pbft_type(PBFT_MSG_PREPREPARE))))
                 .Times(Exactly(1));
@@ -260,7 +260,7 @@ namespace bzn
         for (auto const &p : TEST_PEER_LIST)
         {
             EXPECT_CALL(*(this->mock_node),
-                send_message(bzn::make_endpoint(p),
+                send_signed_message(bzn::make_endpoint(p),
                     AllOf(message_has_req_with_correct_type(bzn_envelope::kPbftInternalRequest),
                         message_has_correct_pbft_type(PBFT_MSG_PREPREPARE))))
                 .Times(Exactly(1));
@@ -287,7 +287,7 @@ namespace bzn
 
         // leave message should be ignored
         EXPECT_CALL(*(this->mock_node),
-            send_message(Matcher<const boost::asio::ip::tcp::endpoint&>(_), AllOf(message_has_req_with_correct_type(bzn_envelope::kPbftInternalRequest),
+            send_signed_message(Matcher<const boost::asio::ip::tcp::endpoint&>(_), AllOf(message_has_req_with_correct_type(bzn_envelope::kPbftInternalRequest),
                 message_has_correct_pbft_type(PBFT_MSG_PREPREPARE))))
             .Times(Exactly(0));
 
@@ -337,7 +337,7 @@ namespace bzn
         for (auto const &p : TEST_PEER_LIST)
         {
             EXPECT_CALL(*(mock_node),
-                send_message(bzn::make_endpoint(p),
+                send_signed_message(bzn::make_endpoint(p),
                     AllOf(message_has_correct_req_hash(msg.request_hash()),
                         message_has_correct_pbft_type(PBFT_MSG_COMMIT))))
                 .Times(Exactly(1));
@@ -398,7 +398,7 @@ namespace bzn
         for (auto const &p : TEST_PEER_LIST)
         {
             EXPECT_CALL(*(mock_node),
-                send_message(bzn::make_endpoint(p),
+                send_signed_message(bzn::make_endpoint(p),
                     AllOf(message_has_correct_req_hash(msg.request_hash()),
                         message_has_correct_pbft_type(PBFT_MSG_COMMIT))))
                 .Times(Exactly(1));
@@ -438,7 +438,7 @@ namespace bzn
         // when timer callback is called, pbft should broadcast viewchange message
         for (auto const &p : TEST_PEER_LIST)
         {
-            EXPECT_CALL(*mock_node, send_message(bzn::make_endpoint(p), ResultOf(is_viewchange, Eq(true))))
+            EXPECT_CALL(*mock_node, send_signed_message(bzn::make_endpoint(p), ResultOf(is_viewchange, Eq(true))))
                 .Times((Exactly(1)))
                 .WillRepeatedly(Invoke([&](auto, auto wmsg)
                 {
@@ -451,7 +451,7 @@ namespace bzn
         }
 
         // once second pbft gets f+1 viewchanges it will broadcast a viewchange message
-        EXPECT_CALL(*mock_node2, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_viewchange, Eq(true))))
+        EXPECT_CALL(*mock_node2, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_viewchange, Eq(true))))
             .Times((Exactly(TEST_PEER_LIST.size())))
             .WillRepeatedly(Invoke([&](auto, auto wmsg)
             {
@@ -461,7 +461,7 @@ namespace bzn
 
         auto newview_env = std::make_shared<bzn_envelope>();
         // second pbft should send a newview with the new configuration
-        EXPECT_CALL(*mock_node2, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_newview, Eq(true))))
+        EXPECT_CALL(*mock_node2, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_newview, Eq(true))))
             .Times((Exactly(TEST_PEER_LIST.size() + 1)))
             .WillRepeatedly(Invoke([&](auto, auto wmsg) {
                 pbft_msg msg;
@@ -518,7 +518,7 @@ namespace bzn
     TEST_F(pbft_join_leave_test, node_not_in_swarm_asks_to_join)
     {
         this->uuid = "somenode";
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_join, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_join, Eq(true))))
             .Times(Exactly(1))
             .WillOnce(Invoke([&](auto, auto)
             {
@@ -532,7 +532,7 @@ namespace bzn
 
     TEST_F(pbft_join_leave_test, node_in_swarm_doesnt_ask_to_join)
     {
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_join, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_join, Eq(true))))
             .Times(Exactly(0));
         this->build_pbft();
     }
@@ -545,7 +545,7 @@ namespace bzn
         for (auto const &p : TEST_PEER_LIST)
         {
             EXPECT_CALL(*(this->mock_node),
-                send_message(bzn::make_endpoint(p), ResultOf(test::is_preprepare, Eq(true))))
+                send_signed_message(bzn::make_endpoint(p), ResultOf(test::is_preprepare, Eq(true))))
                 .Times(Exactly(1))
                 .WillOnce(Invoke([&](auto, auto &envelope)
                 {
@@ -558,7 +558,7 @@ namespace bzn
                     if (p.uuid == TEST_NODE_UUID)
                     {
                         EXPECT_CALL(*(mock_node),
-                            send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_prepare, Eq(true))))
+                            send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_prepare, Eq(true))))
                             .Times(Exactly(TEST_PEER_LIST.size()));
 
                         // reflect the pre-prepare back
@@ -581,7 +581,7 @@ namespace bzn
         for (auto const &p : TEST_PEER_LIST)
         {
             EXPECT_CALL(*(this->mock_node),
-                send_message(bzn::make_endpoint(p), ResultOf(test::is_commit, Eq(true))))
+                send_signed_message(bzn::make_endpoint(p), ResultOf(test::is_commit, Eq(true))))
                 .Times(Exactly(1))
                 .WillOnce(Invoke([&](auto, auto &wmsg)
                 {

--- a/pbft/test/pbft_newview_test.cpp
+++ b/pbft/test/pbft_newview_test.cpp
@@ -81,7 +81,7 @@ namespace bzn
         this->run_transaction_through_primary_times(2, current_sequence);
 
         bzn_envelope viewchange_envelope;
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true))))
                 .WillRepeatedly(Invoke([&](const auto & /*endpoint*/, const auto& viewchange_env) {viewchange_envelope = *viewchange_env;}));
         this->pbft->handle_failure();
 

--- a/pbft/test/pbft_proto_test.cpp
+++ b/pbft/test/pbft_proto_test.cpp
@@ -31,7 +31,7 @@ namespace bzn
     {
         // after request is sent, SUT will send out pre-prepares to all nodes
         auto operation = std::shared_ptr<pbft_operation>();
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
             .Times(Exactly(TEST_PEER_LIST.size()))
             .WillRepeatedly(Invoke([&](auto, auto wmsg)
             {
@@ -68,7 +68,7 @@ namespace bzn
     pbft_proto_test::send_preprepare(uint64_t sequence, const bzn_envelope& request)
     {
         // after preprepare is sent, SUT will send out prepares to all nodes
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_prepare, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_prepare, Eq(true))))
             .Times(Exactly(TEST_PEER_LIST.size()));
 
         auto peer = *(TEST_PEER_LIST.begin());
@@ -88,7 +88,7 @@ namespace bzn
     pbft_proto_test::send_prepares(uint64_t sequence, const bzn::hash_t& request_hash)
     {
         // after prepares are sent, SUT will send out commits to all nodes
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_commit, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_commit, Eq(true))))
             .Times(Exactly(TEST_PEER_LIST.size()));
 
         for (const auto& peer : TEST_PEER_LIST)
@@ -139,7 +139,7 @@ namespace bzn
             }));
 
         // after enough commits are sent, SUT will send out checkpoint message to all nodes
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_checkpoint, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_checkpoint, Eq(true))))
             .Times(Exactly(TEST_PEER_LIST.size()));
     }
 

--- a/pbft/test/pbft_test.cpp
+++ b/pbft/test/pbft_test.cpp
@@ -34,7 +34,7 @@ namespace bzn::test
     TEST_F(pbft_test, test_requests_fire_preprepare)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_preprepare, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_preprepare, Eq(true))))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         pbft->handle_database_message(this->request_msg, this->mock_session);
@@ -42,7 +42,7 @@ namespace bzn::test
 
     TEST_F(pbft_test, test_forwarded_to_primary_when_not_primary)
     {
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), A<std::shared_ptr<bzn_envelope>>())).Times(1).WillRepeatedly(Invoke(
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), A<std::shared_ptr<bzn_envelope>>())).Times(1).WillRepeatedly(Invoke(
                 [&](auto ep, auto msg)
                 {
                     EXPECT_EQ(ep, make_endpoint(this->pbft->get_primary()));
@@ -71,7 +71,7 @@ namespace bzn::test
     TEST_F(pbft_test, test_different_requests_get_different_sequences)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), _)).WillRepeatedly(Invoke(save_sequences));
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), _)).WillRepeatedly(Invoke(save_sequences));
 
         database_msg req, req2;
         req.mutable_header()->set_nonce(5);
@@ -86,7 +86,7 @@ namespace bzn::test
     TEST_F(pbft_test, test_preprepare_triggers_prepare)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true))))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         this->pbft->handle_message(this->preprepare_msg, default_original_msg);
@@ -96,7 +96,7 @@ namespace bzn::test
     {
         this->build_pbft();
         std::shared_ptr<bzn_envelope> wrapped_msg;
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), _)).WillRepeatedly(SaveArg<1>(&wrapped_msg));
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), _)).WillRepeatedly(SaveArg<1>(&wrapped_msg));
 
         this->pbft->handle_message(this->preprepare_msg, default_original_msg);
 
@@ -110,7 +110,7 @@ namespace bzn::test
     TEST_F(pbft_test, test_wrong_view_preprepare_rejected)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), _)).Times(Exactly(0));
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), _)).Times(Exactly(0));
 
         pbft_msg preprepare2(this->preprepare_msg);
         preprepare2.set_view(6);
@@ -121,7 +121,7 @@ namespace bzn::test
     TEST_F(pbft_test, test_no_duplicate_prepares_same_sequence_number)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), _)).Times(Exactly(TEST_PEER_LIST.size()));
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), _)).Times(Exactly(TEST_PEER_LIST.size()));
 
         pbft_msg preprepare2(this->preprepare_msg);
         preprepare2.set_request_hash("some other hash");
@@ -133,9 +133,9 @@ namespace bzn::test
     TEST_F(pbft_test, test_commit_messages_sent)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true))))
                 .Times(Exactly(TEST_PEER_LIST.size()));
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_commit, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_commit, Eq(true))))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         this->pbft->handle_message(this->preprepare_msg, default_original_msg);
@@ -204,7 +204,7 @@ namespace bzn::test
     TEST_F(pbft_test, client_request_executed_results_in_message_response)
     {
         auto mock_session = std::make_shared<bzn::Mocksession_base>();
-        EXPECT_CALL(*mock_session, send_message(_)).Times(Exactly(1));
+        EXPECT_CALL(*mock_session, send_message(A<std::shared_ptr<std::string>>())).Times(Exactly(1));
 
         auto peers = std::make_shared<const std::vector<bzn::peer_address_t>>();
         auto op = std::make_shared<pbft_memory_operation>(1, 1, "somehash", peers);
@@ -219,7 +219,7 @@ namespace bzn::test
     TEST_F(pbft_test, messages_after_high_water_mark_dropped)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true))))
                 .Times(Exactly(0));
 
         this->preprepare_msg.set_sequence(pbft->get_high_water_mark() + 1);
@@ -229,7 +229,7 @@ namespace bzn::test
     TEST_F(pbft_test, messages_before_low_water_mark_dropped)
     {
         this->build_pbft();
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true))))
                 .Times(Exactly(0));
 
         this->preprepare_msg.set_sequence(this->pbft->get_low_water_mark());

--- a/pbft/test/pbft_timestamp_test.cpp
+++ b/pbft/test/pbft_timestamp_test.cpp
@@ -39,14 +39,14 @@ namespace bzn
         request->set_sender(TEST_NODE_UUID);
 
         // the first time we should get pre-prepare messages
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
             .Times(Exactly(TEST_PEER_LIST.size()));
         this->handle_request(*request);
 
         auto request2 = new bzn_envelope(*request);
 
         // this time no pre-prepare should be issued
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
             .Times(Exactly(0));
         this->handle_request(*request2);
     }
@@ -69,7 +69,7 @@ namespace bzn
         request->set_sender(TEST_NODE_UUID);
 
         // we should get pre-prepare messages
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
             .Times(Exactly(TEST_PEER_LIST.size()));
         this->handle_request(*request);
 
@@ -79,7 +79,7 @@ namespace bzn
         request2->set_timestamp(request2->timestamp() + 1);
 
         // again we should get pre-prepare messages
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
             .Times(Exactly(TEST_PEER_LIST.size()));
         this->handle_request(*request2);
 
@@ -95,7 +95,7 @@ namespace bzn
         request3->set_database_msg(dmsg3->SerializeAsString());
 
         // again we should get pre-prepare messages
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
             .Times(Exactly(TEST_PEER_LIST.size()));
         this->handle_request(*request3);
     }
@@ -118,7 +118,7 @@ namespace bzn
         request->set_sender(TEST_NODE_UUID);
 
         // we should get pre-prepare messages
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
             .Times(Exactly(TEST_PEER_LIST.size()));
         this->handle_request(*request);
 
@@ -127,7 +127,7 @@ namespace bzn
         request2->set_sender(SECOND_NODE_UUID);
 
         // again we should get pre-prepare messages
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
             .Times(Exactly(TEST_PEER_LIST.size()));
         this->handle_request(*request2);
     }
@@ -149,7 +149,7 @@ namespace bzn
         request->set_sender(TEST_NODE_UUID);
 
         // we should NOT get pre-prepare messages since this is an old request
-        EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
+        EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_preprepare, Eq(true))))
             .Times(Exactly(0));
         this->handle_request(*request);
     }

--- a/pbft/test/pbft_viewchange_test.cpp
+++ b/pbft/test/pbft_viewchange_test.cpp
@@ -162,7 +162,7 @@ namespace bzn
 
         this->run_transaction_through_primary_times(2, current_sequence);
 
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true))))
                 .WillRepeatedly(Invoke(
                         [&](const auto & /*endpoint*/, const auto &viewchange_env)
                         {
@@ -206,7 +206,7 @@ namespace bzn
 
         this->run_transaction_through_primary_times(2, current_sequence);
 
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true))))
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true))))
                 .WillRepeatedly(Invoke([&](const auto & /*endpoint*/, const auto viewchange_env)
                 {
                     EXPECT_EQ(this->pbft->get_uuid(), viewchange_env->sender());
@@ -381,7 +381,7 @@ namespace bzn
         for (auto const &p : TEST_PEER_LIST)
         {
             EXPECT_CALL(*(this->mock_node),
-                        send_message(bzn::make_endpoint(p), ResultOf(test::is_viewchange, Eq(true))))
+                        send_signed_message(bzn::make_endpoint(p), ResultOf(test::is_viewchange, Eq(true))))
                     .Times(Exactly(1))
                     .WillRepeatedly(Invoke([&](auto, auto wmsg)
                                            {
@@ -395,13 +395,13 @@ namespace bzn
 
         for (auto const &p : TEST_PEER_LIST)
         {
-            EXPECT_CALL(*mock_node2, send_message(bzn::make_endpoint(p), ResultOf(test::is_newview, Eq(true))))
+            EXPECT_CALL(*mock_node2, send_signed_message(bzn::make_endpoint(p), ResultOf(test::is_newview, Eq(true))))
                     .Times(Exactly(1))
                     .WillRepeatedly(Invoke([&](auto, auto wmsg)
                                            {
                                                 if (p.uuid == TEST_NODE_UUID)
                                                {
-                                                   EXPECT_CALL(*this->mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_prepare, Eq(true))))
+                                                   EXPECT_CALL(*this->mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_prepare, Eq(true))))
                                                            .Times(Exactly(2 * TEST_PEER_LIST.size()));
                                                    pbft_msg msg;
                                                    ASSERT_TRUE(msg.ParseFromString(wmsg->pbft()));
@@ -410,7 +410,7 @@ namespace bzn
                                            }));
         }
 
-        EXPECT_CALL(*mock_node2, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true))))
+        EXPECT_CALL(*mock_node2, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true))))
                 .Times(Exactly(TEST_PEER_LIST.size()));
 
         // get sut1 to generate viewchange message
@@ -432,7 +432,7 @@ namespace bzn
 
         EXPECT_CALL(*mock_crypto, hash(An<const bzn_envelope&>())).WillRepeatedly(Invoke([&](const bzn_envelope& envelope)
             {return envelope.sender() + "_" + std::to_string(current_sequence) + "_" + std::to_string(envelope.timestamp());}));
-        EXPECT_CALL(*mock_node, send_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true)))).WillRepeatedly(Invoke([&](const auto & /*endpoint*/, const auto &viewchange_env)
+        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(test::is_viewchange, Eq(true)))).WillRepeatedly(Invoke([&](const auto & /*endpoint*/, const auto &viewchange_env)
             { original_message = *viewchange_env; }));
 
         this->run_transaction_through_primary_times(1, current_sequence);

--- a/proto/database.proto
+++ b/proto/database.proto
@@ -54,7 +54,7 @@ message database_header
 {
     string db_uuid = 1;
     uint64 nonce = 2 [jstype = JS_STRING];
-    bytes  point_of_contact = 3;
+    string  point_of_contact = 3;
     bytes  request_hash = 4;
 }
 

--- a/scripts/crud
+++ b/scripts/crud
@@ -48,6 +48,8 @@ def handle_response(ws):
 
     env = bluzelle_pb2.bzn_envelope()
     env.ParseFromString(ws.recv())
+    print("Response: \n{}".format(env).expandtabs(4))
+    print("-" * 60 + '\n')
 
     resp = database_pb2.database_response()
     resp.ParseFromString(env.database_response)

--- a/status/status.cpp
+++ b/status/status.cpp
@@ -106,8 +106,6 @@ status::handle_status_request_message(const bzn_envelope& /*msg*/, std::shared_p
 
     bzn_envelope env;
     env.set_status_response(srm.SerializeAsString());
-    env.set_sender("placeholder for daemon's uuid"); // TODO
-    // TODO: crypto
 
-    session->send_message(std::make_shared<bzn::encoded_message>(env.SerializeAsString()));
+    session->send_signed_message(std::make_shared<bzn_envelope>(env));
 }

--- a/status/test/status_test.cpp
+++ b/status/test/status_test.cpp
@@ -79,16 +79,13 @@ TEST(status_test, test_that_status_request_queries_status_providers)
             return status;
         }));
 
-    EXPECT_CALL(*mock_session, send_message(An<std::shared_ptr<bzn::encoded_message>>())).WillOnce(Invoke(
-        [&](std::shared_ptr<bzn::encoded_message> msg)
+    EXPECT_CALL(*mock_session, send_signed_message(_)).WillOnce(Invoke(
+        [&](auto env)
         {
-            bzn_envelope env;
-
-            ASSERT_TRUE(env.ParseFromString(*msg));
-            ASSERT_EQ(env.payload_case(), bzn_envelope::kStatusResponse);
+            ASSERT_EQ(env->payload_case(), bzn_envelope::kStatusResponse);
 
             status_response sr;
-            ASSERT_TRUE(sr.ParseFromString(env.status_response()));
+            ASSERT_TRUE(sr.ParseFromString(env->status_response()));
             ASSERT_TRUE(sr.pbft_enabled());
             ASSERT_EQ(sr.swarm_version(), SWARM_VERSION);
             ASSERT_EQ(sr.swarm_git_commit(), SWARM_GIT_COMMIT);


### PR DESCRIPTION
changed point of contact field to string
removed placeholder uuids from crud
moved message signing into session, changed method names to clarify
intent