### PR TITLE
kep-1031 - attempting to ensure that peers list is valid by throwing …

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,14 @@ line argument:
 The configuration file is a JSON format file, as seen in the following example:
 
     {
-				"listener_address" : "127.0.0.1",
-				"listener_port" : 50000,
-				"ethereum" : "0xddbd2b932c763ba5b1b7ae3b362eac3e8d40121a",
-				"ethereum_io_api_token" : "<your API key here>",
-				"bootstrap_file" : "/home/isabel/swarmdb/local/nodes/peers.json",
-				"debug_logging" : true,
-				"log_to_stdout" : true,
-				"use_pbft": true,
+        "listener_address" : "127.0.0.1",
+        "listener_port" : 50000,
+        "ethereum" : "0xddbd2b932c763ba5b1b7ae3b362eac3e8d40121a",
+        "ethereum_io_api_token" : "<your API key here>",
+        "bootstrap_file" : "/home/isabel/swarmdb/local/nodes/peers.json",
+        "debug_logging" : true,
+        "log_to_stdout" : true,
+        "use_pbft": true,
         "bootstrap_file": "./peers.json",
     }
 

--- a/pbft/test/pbft_test.cpp
+++ b/pbft/test/pbft_test.cpp
@@ -251,8 +251,8 @@ namespace bzn::test
         return arg->has_session();
     }
 
-    TEST_F(pbft_test, request_redirect_attaches_session) {
-
+    TEST_F(pbft_test, request_redirect_attaches_session)
+    {
         EXPECT_CALL(*mock_service, apply_operation(operation_ptr_has_session()));
         EXPECT_CALL(*mock_io_context, post(_)).WillRepeatedly(Invoke(
                 [](const auto task)
@@ -275,8 +275,8 @@ namespace bzn::test
         this->send_commits(1, 1, hash);
     }
 
-    TEST_F(pbft_test, late_request_redirect_attaches_session) {
-
+    TEST_F(pbft_test, late_request_redirect_attaches_session)
+    {
         EXPECT_CALL(*mock_service, apply_operation(operation_ptr_has_session()));
         EXPECT_CALL(*mock_io_context, post(_)).WillRepeatedly(Invoke(
                 [](const auto task)

--- a/pbft/test/pbft_test_common.hpp
+++ b/pbft/test/pbft_test_common.hpp
@@ -49,6 +49,17 @@ namespace bzn::test
                                            , {"127.0.0.1", 8083, 8883, "name3", "uuid3"}
                                            , {TEST_NODE_ADDR, TEST_NODE_LISTEN_PORT, TEST_NODE_HTTP_PORT, "name4", TEST_NODE_UUID}};
 
+    const std::string TEST_NODE_ADDR_0("127.0.0.1");
+
+    const bzn::peers_list_t BAD_TEST_PEER_LIST_0{{ "127.0.0.1", 8081, 8881, "name1", "uuid0"}
+                                                , {"127.0.0.1", 8082, 8882, "name2", "uuid2"}
+                                                , {"127.0.0.1", 8083, 8883, "name3", "uuid3"}
+                                                , {TEST_NODE_ADDR_0, TEST_NODE_LISTEN_PORT, TEST_NODE_HTTP_PORT, "name4", "uuid_of_bad_node"}};
+
+    const bzn::peers_list_t GOOD_TEST_PEER_LIST{{ "127.0.0.1", 8081, 8881, "name1", "uuid0"}
+                                                , {"127.0.0.1", 8082, 8882, "name2", "uuid2"}
+                                                , {"127.0.0.1", 8083, 8883, "name3", "uuid3"}
+                                                , {TEST_NODE_ADDR_0, uint16_t(TEST_NODE_LISTEN_PORT + 73), TEST_NODE_HTTP_PORT, "name4", "uuid_of_good_node"}};
 
     class pbft_test : public Test
     {


### PR DESCRIPTION
…an runtime exception when a peer is found in the list that duplicates the current nodes' IP and port number