### PR TITLE
KEP-973: pbft variables reside in storage

### DIFF
--- a/pbft/CMakeLists.txt
+++ b/pbft/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(pbft STATIC
     pbft_config_store.cpp
     database_pbft_service.cpp
     database_pbft_service.hpp
-    )
+    pbft_persistent_state.cpp)
 
 target_link_libraries(pbft utils pbft_operations proto)
 target_include_directories(pbft PRIVATE ${JSONCPP_INCLUDE_DIRS} ${PROTO_INCLUDE_DIR})

--- a/pbft/database_pbft_service.cpp
+++ b/pbft/database_pbft_service.cpp
@@ -140,6 +140,14 @@ database_pbft_service::process_awaiting_operations()
                 this->crud->handle_request(op_it->second->get_request().sender(), request, nullptr);
             }
 
+            if (this->next_request_sequence == this->next_checkpoint)
+            {
+                if (this->crud->save_state())
+                {
+                    this->last_checkpoint = this->next_request_sequence;
+                }
+            }
+
             this->io_context->post(std::bind(this->execute_handler, (*op_it).second));
         }
 
@@ -147,14 +155,6 @@ database_pbft_service::process_awaiting_operations()
         {
             // these are fatal... something bad is going on.
             throw std::runtime_error("Failed to remove pbft_request from database! (" + std::to_string(uint8_t(result)) + ")");
-        }
-
-        if (this->next_request_sequence == this->next_checkpoint)
-        {
-            if (this->crud->save_state())
-            {
-                this->last_checkpoint = this->next_request_sequence;
-            }
         }
 
         ++this->next_request_sequence;
@@ -166,7 +166,7 @@ database_pbft_service::process_awaiting_operations()
 bzn::hash_t
 database_pbft_service::service_state_hash(uint64_t /*sequence_number*/) const
 {
-    // TODO: not sure how this works...
+    // TODO: not sure how this works... (KEP-1203)
 
     return "";
 }

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -44,17 +44,17 @@ namespace
     const uint64_t MAX_REQUEST_AGE_MS = 300000; // 5 minutes
     const std::string NOOP_REQUEST_HASH = "<no op request hash>";
 
-    std::string VIEW_KEY{"view"};
-    std::string NEXT_ISSUED_SEQUENCE_NUMBER_KEY{"next_issued_sequence_number"};
-    std::string ACCEPTED_PREPREPARES_KEY{"accepted_preprepares"};
-    std::string STABLE_CHECKPOINT_KEY{"stable_checkpoint"};
-    std::string LOCAL_UNSTABLE_CHECKPOINTS_KEY{"local_unstable_checkpoints"};
-    std::string UNSTABLE_CHECKPOINT_PROOFS_KEY{"unstable_checkpoint_proofs"};
-    std::string STABLE_CHECKPOINT_PROOF_KEY{"stable_checkpoint_proof"};
-    std::string VIEW_IS_VALID_KEY{"view_is_valid"};
-    std::string LAST_VIEW_SENT_KEY{"last_view_sent"};
-    std::string VALID_VIEWCHANGE_MESSAGES_FOR_VIEW_KEY{"valid_viewchange_messages_for_view"};
-    std::string SAVED_NEWVIEW_KEY{"saved_newview"};
+    const std::string VIEW_KEY{"view"};
+    const std::string NEXT_ISSUED_SEQUENCE_NUMBER_KEY{"next_issued_sequence_number"};
+    const std::string ACCEPTED_PREPREPARES_KEY{"accepted_preprepares"};
+    const std::string STABLE_CHECKPOINT_KEY{"stable_checkpoint"};
+    const std::string LOCAL_UNSTABLE_CHECKPOINTS_KEY{"local_unstable_checkpoints"};
+    const std::string UNSTABLE_CHECKPOINT_PROOFS_KEY{"unstable_checkpoint_proofs"};
+    const std::string STABLE_CHECKPOINT_PROOF_KEY{"stable_checkpoint_proof"};
+    const std::string VIEW_IS_VALID_KEY{"view_is_valid"};
+    const std::string LAST_VIEW_SENT_KEY{"last_view_sent"};
+    const std::string VALID_VIEWCHANGE_MESSAGES_FOR_VIEW_KEY{"valid_viewchange_messages_for_view"};
+    const std::string SAVED_NEWVIEW_KEY{"saved_newview"};
 }
 
 

--- a/pbft/pbft_config_store.cpp
+++ b/pbft/pbft_config_store.cpp
@@ -19,15 +19,8 @@ using namespace bzn;
 pbft_config_store::pbft_config_store(std::shared_ptr<bzn::storage_base> storage)
 : storage(storage)
 {
-    persistent<config_info>::initialize<hash_t>(this->storage, CONFIG_STORE_CONFIGS_KEY, [this](const persistent<config_info>& value, auto key)
-    {
-        this->configs.emplace(key, value);
-    });
-
-    persistent<hash_t>::initialize<uint64_t>(this->storage, CONFIG_STORE_VIEW_CONFIGS_KEY, [this](auto value, auto key)
-    {
-        this->view_configs.emplace(key, value);
-    });
+    persistent<config_info>::init_kv_container<hash_t>(this->storage, CONFIG_STORE_CONFIGS_KEY, this->configs);
+    persistent<hash_t>::init_kv_container<uint64_t>(this->storage, CONFIG_STORE_VIEW_CONFIGS_KEY, this->view_configs);
 }
 
 void

--- a/pbft/pbft_config_store.cpp
+++ b/pbft/pbft_config_store.cpp
@@ -16,15 +16,30 @@
 
 using namespace bzn;
 
+pbft_config_store::pbft_config_store(std::shared_ptr<bzn::storage_base> storage)
+: storage(storage)
+{
+    persistent<config_info>::initialize<hash_t>(this->storage, CONFIG_STORE_CONFIGS_KEY, [this](const persistent<config_info>& value, auto key)
+    {
+        this->configs.emplace(key, value);
+    });
+
+    persistent<hash_t>::initialize<uint64_t>(this->storage, CONFIG_STORE_VIEW_CONFIGS_KEY, [this](auto value, auto key)
+    {
+        this->view_configs.emplace(key, value);
+    });
+}
+
 void
 pbft_config_store::add(pbft_configuration::shared_const_ptr config)
 {
-    auto res = this->configs.insert(std::make_pair(config->get_hash(), config_info{++this->index, config}));
+    this->index = this->index.value() + 1;
+    auto res = this->configs.insert({config->get_hash()
+        , {this->storage, {this->index.value(), config}, CONFIG_STORE_CONFIGS_KEY, config->get_hash()}});
     if (!res.second)
     {
         // reset the configuration info without losing its previous view(s)
-        res.first->second.index = this->index;
-        res.first->second.state = pbft_config_state::accepted;
+        res.first->second = {this->index.value(), config, pbft_config_state::accepted, res.first->second.value().views};
     }
 }
 
@@ -32,14 +47,14 @@ pbft_configuration::shared_const_ptr
 pbft_config_store::get(const hash_t& hash) const
 {
     auto it = this->configs.find(hash);
-    return it == this->configs.end() ? nullptr : it->second.config;
+    return it == this->configs.end() ? nullptr : it->second.value().config;
 }
 
 pbft_configuration::shared_const_ptr
 pbft_config_store::get(uint64_t view) const
 {
     auto it = this->view_configs.find(view);
-    return it == this->view_configs.end() ? nullptr : get(it->second);
+    return it == this->view_configs.end() ? nullptr : this->get(it->second.value());
 }
 
 bool
@@ -56,9 +71,13 @@ pbft_config_store::set_committed(const hash_t& hash)
         // when a configuration is committed, we won't accept new_view with any earlier config
         for (auto& elem : this->configs)
         {
-            if (elem.second.state != pbft_config_state::current && elem.second.index < this->configs[hash].index)
+            auto it = this->configs.find(hash);
+            assert(it != this->configs.end());
+
+            if (elem.second.value().state != pbft_config_state::current && elem.second.value().index
+                < it->second.value().index)
             {
-                elem.second.state = pbft_config_state::deprecated;
+                this->set_state(elem.first, pbft_config_state::deprecated);
             }
         }
 
@@ -80,21 +99,24 @@ pbft_config_store::set_current(const hash_t& hash, uint64_t view)
     auto it = this->configs.find(hash);
     if (it != this->configs.end())
     {
-        it->second.state = pbft_config_state::current;
-        it->second.views.insert(view);
-        this->view_configs[view] = hash;
+        auto mutable_config{it->second.value()};
+        mutable_config.state = pbft_config_state::current;
+        mutable_config.views.insert(view);
+        it->second = mutable_config;
 
+        this->view_configs[view] = persistent<hash_t>{this->storage, hash, CONFIG_STORE_VIEW_CONFIGS_KEY, view};
         this->current_config = hash;
         return true;
     }
+
     return false;
 }
 
 pbft_configuration::shared_const_ptr
 pbft_config_store::current() const
 {
-    auto it = this->configs.find(this->current_config);
-    return it == this->configs.end() ? nullptr : it->second.config;
+    auto it = this->configs.find(this->current_config.value());
+    return it == this->configs.end() ? nullptr : it->second.value().config;
 }
 
 hash_t
@@ -113,7 +135,7 @@ pbft_config_store::pbft_config_state
 pbft_config_store::get_state(const hash_t& hash) const
 {
     auto it = this->configs.find(hash);
-    return it == this->configs.end() ? pbft_config_state::unknown : it->second.state;
+    return it == this->configs.end() ? pbft_config_state::unknown : it->second.value().state;
 }
 
 bool pbft_config_store::is_acceptable(const hash_t& hash) const
@@ -127,7 +149,9 @@ pbft_config_store::set_state(const hash_t& hash, pbft_config_state state)
     auto it = this->configs.find(hash);
     if (it != this->configs.end())
     {
-        it->second.state = state;
+        auto mutable_config{it->second.value()};
+        mutable_config.state = state;
+        it->second = mutable_config;
         return true;
     }
     return false;
@@ -140,15 +164,69 @@ pbft_config_store::newest(const std::list<pbft_config_state>& states) const
     uint64_t max{0};
     for (auto elem : this->configs)
     {
-        if (elem.second.index > max && std::any_of(states.begin(), states.end(), [elem](auto state)
+        if (elem.second.value().index > max && std::any_of(states.begin(), states.end(), [elem](auto state)
         {
-            return elem.second.state == state;
+            return elem.second.value().state == state;
         }))
         {
-            max = elem.second.index;
+            max = elem.second.value().index;
             hash = elem.first;
         }
     }
 
     return hash;
+}
+
+template <>
+std::string
+persistent<pbft_config_store::config_info>::to_string(const pbft_config_store::config_info& info)
+{
+    bzn::json_message json;
+    json["index"] = info.index;
+    json["config"] = info.config->to_json();
+    json["state"] = static_cast<uint64_t>(info.state);
+
+    json["views"] = bzn::json_message();
+    for (auto view : info.views)
+    {
+        json["views"].append(view);
+    }
+
+    return json.toStyledString();
+}
+
+template <>
+pbft_config_store::config_info
+persistent<pbft_config_store::config_info>::from_string(const std::string& value)
+{
+    Json::Value json;
+    Json::Reader reader;
+    if (reader.parse(value, json))
+    {
+        if (json.isMember("index") && json.isMember("config") && json.isMember("state"))
+        {
+            try
+            {
+                pbft_config_store::config_info info;
+                info.index = json["index"].asUInt64();
+
+                pbft_configuration cfg;
+                cfg.from_json(json["config"]);
+                info.config = std::make_shared<pbft_configuration>(cfg);
+                info.state = static_cast<pbft_config_store::pbft_config_state>(json["state"].asUInt64());
+
+                for (auto& v : json["views"])
+                {
+                    info.views.insert(v.asUInt64());
+                }
+
+                return info;
+            }
+            catch(...)
+            {}
+        }
+    }
+
+    LOG(error) << "bad config_info from persistent state";
+    throw std::runtime_error("bad config_info from persistent state");
 }

--- a/pbft/pbft_configuration.cpp
+++ b/pbft/pbft_configuration.cpp
@@ -52,7 +52,19 @@ pbft_configuration::from_string(const std::string& str)
         return false;
     }
 
-    if (!json.isMember("peers") || !json["peers"].isArray())
+    return this->from_json(json);
+}
+
+std::string
+pbft_configuration::to_string() const
+{
+    return this->to_json().toStyledString();
+}
+
+bool
+pbft_configuration::from_json(const Json::Value& json)
+{
+    if (!json.isMember("peers")/* || !json["peers"].isArray()*/)
     {
         LOG(error) << "Invalid configuration: " << json.toStyledString().substr(0, MAX_MESSAGE_SIZE) << "...";
         return false;
@@ -81,8 +93,8 @@ pbft_configuration::from_string(const std::string& str)
     return result;
 }
 
-std::string
-pbft_configuration::to_string() const
+Json::Value
+pbft_configuration::to_json() const
 {
     bzn::json_message json;
     json["peers"] = bzn::json_message();
@@ -98,7 +110,7 @@ pbft_configuration::to_string() const
         json["peers"].append(peer);
     }
 
-    return json.toStyledString();
+    return json;
 }
 
 hash_t

--- a/pbft/pbft_configuration.hpp
+++ b/pbft/pbft_configuration.hpp
@@ -40,6 +40,12 @@ namespace bzn
         // serialize to string
         std::string to_string() const;
 
+        // de-serialize from json - returns true for success
+        bool from_json(const Json::Value& json);
+
+        // serialize to json
+        Json::Value to_json() const;
+
         // returns the hash of this configuration
         hash_t get_hash() const;
 

--- a/pbft/pbft_persistent_state.cpp
+++ b/pbft/pbft_persistent_state.cpp
@@ -1,0 +1,253 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#include <pbft/pbft_persistent_state.hpp>
+#include <boost/format.hpp>
+#include <boost/lexical_cast.hpp>
+#include <pbft/operations/pbft_operation.hpp>
+
+using namespace bzn;
+
+std::string
+persist_base::escape(const std::string& input)
+{
+    std::string output;
+
+    for (auto ch : input)
+    {
+        output += (ch == SEPARATOR) ? std::string{SEPARATOR} + ch : std::string{ch};
+    }
+
+    return output;
+}
+
+std::string
+persist_base::unescape(const std::string& input)
+{
+    std::string output;
+
+    auto it = input.begin();
+    while (it != input.end())
+    {
+        if (*it == SEPARATOR)
+        {
+            if (it + 1 != input.end() && *(it + 1) == SEPARATOR)
+            {
+                output += *it;
+                it += 2;
+            }
+            else
+            {
+                // a bare SEPARATOR character was found, which should never happen.
+                // if you hit this you've likely specified a key incorrectly
+                LOG(error) << "illegal character unescaping key for persistent value";
+                throw std::runtime_error("illegal character unescaping key for persistent value");
+            }
+        }
+        else
+        {
+            output += *it++;
+        }
+    }
+
+    return output;
+}
+
+template<>
+std::string
+persistent<std::string>::to_string(const std::string &value)
+{
+    return value;
+}
+
+template<>
+std::string
+persistent<std::string>::from_string(const std::string &value)
+{
+    return value;
+}
+
+template<>
+std::string
+persistent<bzn::log_key_t>::to_string(const bzn::log_key_t &key)
+{
+    return (boost::format("%020u_%020u") % std::get<0>(key) % std::get<1>(key)).str();
+}
+
+template<>
+bzn::log_key_t
+persistent<bzn::log_key_t>::from_string(const std::string &value)
+{
+    auto offset = value.find('_');
+    if (offset < value.size())
+    {
+        try
+        {
+            uint64_t v0 = boost::lexical_cast<uint64_t>(value.substr(0, offset).c_str());
+            uint64_t v1 = boost::lexical_cast<uint64_t>(value.substr(offset + 1).c_str());
+            if (v0 && v1)
+            {
+                return log_key_t{v0, v1};
+            }
+        }
+        catch (boost::bad_lexical_cast &)
+        {
+            LOG(error) << "Error converting log key from persistent state";
+        }
+    }
+
+    LOG(error) << "bad log key from persistent state";
+    throw std::runtime_error("bad log key from persistent state");
+//    return log_key_t{0, 0};
+}
+
+template<>
+std::string
+persistent<bzn::operation_key_t>::to_string(const bzn::operation_key_t &key)
+{
+    return (boost::format("%020u_%020u_%s") % std::get<0>(key) % std::get<1>(key) % std::get<2>(key)).str();
+}
+
+template<>
+bzn::operation_key_t
+persistent<bzn::operation_key_t>::from_string(const std::string &value)
+{
+    auto offset1 = value.find('_');
+    if (offset1 < value.size())
+    {
+        auto offset2 = value.find('_', offset1 + 1);
+        if (offset2 < value.size())
+        {
+            try
+            {
+                uint64_t v0 = boost::lexical_cast<uint64_t>(value.substr(0, offset1).c_str());
+                uint64_t v1 = boost::lexical_cast<uint64_t>(
+                    value.substr(offset1 + 1, offset2 - (offset1 + 1)).c_str());
+                if (v0 && v1 && !value.substr(offset2 + 1).empty())
+                {
+                    return operation_key_t{v0, v1, value.substr(offset2 + 1)};
+                }
+            }
+            catch (boost::bad_lexical_cast &)
+            {
+                LOG(warning) << "Error converting operation key";
+            }
+        }
+    }
+
+    LOG(error) << "bad log key from persistent state";
+    throw std::runtime_error("bad log key from persistent state");
+    //return operation_key_t{0, 0, "<bad hash>"};
+}
+
+template<>
+std::string
+persistent<bzn::checkpoint_t>::to_string(const bzn::checkpoint_t &cp)
+{
+    return (boost::format("%020u_%s") % cp.first % cp.second).str();
+}
+
+template<>
+bzn::checkpoint_t
+persistent<bzn::checkpoint_t>::from_string(const std::string &value)
+{
+    auto offset = value.find('_');
+    if (offset < value.size())
+    {
+        try
+        {
+            uint64_t v0 = boost::lexical_cast<uint64_t>(value.substr(0, offset).c_str());
+
+            // TODO: checkpoint hashes are currently empty. remove comments after they're done (KEP-1203)
+//            if (!value.substr(offset + 1).empty())
+//            {
+                return checkpoint_t{v0, value.substr(offset + 1)};
+//            }
+        }
+        catch (boost::bad_lexical_cast &)
+        {
+            LOG(warning) << "Error converting checkpoint";
+        }
+    }
+
+    LOG(error) << "bad checkpoint from persistent state";
+    throw std::runtime_error("bad checkpoint from persistent state");
+}
+
+template <>
+std::string
+persistent<uint64_t>::to_string(const uint64_t& val)
+{
+    return (boost::format("%020u") % val).str();
+}
+
+template <>
+uint64_t
+persistent<uint64_t>::from_string(const std::string& value)
+{
+    try
+    {
+        return boost::lexical_cast<uint64_t>(value);
+    }
+    catch (boost::bad_lexical_cast &)
+    {
+    }
+
+    LOG(error) << "bad uint64_t from persistent state";
+    throw std::runtime_error("bad uint64_t from persistent state");
+}
+
+template<>
+std::string
+persistent<bool>::to_string(const bool &val)
+{
+    return (boost::format("%01u") % val).str();
+}
+
+template<>
+bool
+persistent<bool>::from_string(const std::string &value)
+{
+    try
+    {
+        return boost::lexical_cast<bool>(value);
+    }
+    catch (boost::bad_lexical_cast &)
+    {
+    }
+
+    LOG(error) << "bad bool from persistent state";
+    throw std::runtime_error("bad bool from persistent state");
+}
+
+template<>
+std::string
+persistent<bzn_envelope>::to_string(const bzn_envelope &val)
+{
+    return val.SerializeAsString();
+}
+
+template<>
+bzn_envelope
+persistent<bzn_envelope>::from_string(const std::string &value)
+{
+    bzn_envelope env;
+    if (env.ParseFromString(value))
+    {
+        return env;
+    }
+
+    LOG(error) << "bad bzn_envelope from persistent state";
+    throw std::runtime_error("bad bzn_envelope from persistent state");
+}

--- a/pbft/pbft_persistent_state.cpp
+++ b/pbft/pbft_persistent_state.cpp
@@ -19,6 +19,8 @@
 
 using namespace bzn;
 
+std::set<std::string> persist_base::initialized_containers;
+
 std::string
 persist_base::escape(const std::string& input)
 {
@@ -26,7 +28,7 @@ persist_base::escape(const std::string& input)
 
     for (auto ch : input)
     {
-        output += (ch == SEPARATOR) ? std::string{SEPARATOR} + ch : std::string{ch};
+        output += (ch == ESCAPE_1) ? std::string{ESCAPE_1} + ESCAPE_2 : std::string{ch};
     }
 
     return output;
@@ -40,16 +42,16 @@ persist_base::unescape(const std::string& input)
     auto it = input.begin();
     while (it != input.end())
     {
-        if (*it == SEPARATOR)
+        if (*it == ESCAPE_1)
         {
-            if (it + 1 != input.end() && *(it + 1) == SEPARATOR)
+            if (it + 1 != input.end() && *(it + 1) == ESCAPE_2)
             {
                 output += *it;
                 it += 2;
             }
             else
             {
-                // a bare SEPARATOR character was found, which should never happen.
+                // a bare ESCAPE_1 character was found, which should never happen.
                 // if you hit this you've likely specified a key incorrectly
                 LOG(error) << "illegal character unescaping key for persistent value";
                 throw std::runtime_error("illegal character unescaping key for persistent value");
@@ -109,7 +111,6 @@ persistent<bzn::log_key_t>::from_string(const std::string &value)
 
     LOG(error) << "bad log key from persistent state";
     throw std::runtime_error("bad log key from persistent state");
-//    return log_key_t{0, 0};
 }
 
 template<>
@@ -148,7 +149,6 @@ persistent<bzn::operation_key_t>::from_string(const std::string &value)
 
     LOG(error) << "bad log key from persistent state";
     throw std::runtime_error("bad log key from persistent state");
-    //return operation_key_t{0, 0, "<bad hash>"};
 }
 
 template<>

--- a/pbft/pbft_persistent_state.hpp
+++ b/pbft/pbft_persistent_state.hpp
@@ -183,15 +183,13 @@ namespace bzn
         static T from_string(const std::string& /*value*/)
         {
             // this method needs to be specialized for each type used
-            assert(0);
-            return T{};
+            throw std::runtime_error("no conversion available for this type from string");
         }
 
         static std::string to_string(const T& /*value*/)
         {
             // this method needs to be specialized for each type used
-            assert(0);
-            return std::string{};
+            throw std::runtime_error("no conversion available for this type to string");
         }
 
         // initialize values in a container

--- a/pbft/pbft_persistent_state.hpp
+++ b/pbft/pbft_persistent_state.hpp
@@ -1,0 +1,257 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <storage/storage_base.hpp>
+#include <boost/format.hpp>
+#include <boost/lexical_cast.hpp>
+
+namespace
+{
+    const char SEPARATOR = '/';
+    const std::string STATE_UUID{"pbftstate"};
+}
+
+namespace bzn
+{
+    using checkpoint_t = std::pair<uint64_t, bzn::hash_t>;
+
+    class persist_base
+    {
+    protected:
+        static std::string escape(const std::string& input);
+        static std::string unescape(const std::string& input);
+    };
+
+    // A persistent value that is stored with a unique key specified by an object name and a series of
+    // zero or more sub-keys. The sub-keys are used to create a unique storage key for each element within a
+    // (possibly nested) collection such as a map or set.
+    //
+    // For non-collection types, declare an object of type persistent<type> and initialize it with
+    // { storage, default-value, unique-key }. If the variable already exists in storage it will be initialized
+    // with its stored state. If not it will use the provided default value.
+    //
+    // For collections, at instantiation time (e.g. insert, emplace, etc), insert the value as
+    // { storage, value, unique-object-name, key-name, key-name... }, where the key-names are the
+    // keys for each nested map, set, vector, etc.
+    // E.g. for map<int, persistent<std::string>> items, you would insert a string mapped to the integer 9 using:
+    // map.insert(std::make_pair(9, {storage, "value", "items", 9}); which would yield a storage key "items_00009".
+    //
+    // In the case of nested maps, multiple subkeys are needed to guarantee the uniqueness of the generated
+    // storage key. e.g. for map<int, map<char, persistent<string>>> nesty; you would insert an item in the 7 map,
+    // mapped to the char 'x' like so: nesty[7]['x'] = {storage, "value", "nesty", 'x', 7}; which would yield a
+    // storage key "nesty_x_00007".
+    //
+    // For consistency, it's recommended that in nested collections the sub-keys be ordered from inner to outer.
+    //
+    // To initialize the contents of a collection from persistent storage at startup, use one of the initialize()
+    // methods defined below, providing a lambda function which emplaces each provided key(s)/value into the container.
+    // E.g. to initialize a map<int, persistent<string>> you would do:
+    //   persistent<string>::initialize<int>(storage, "mapname", [&](auto value, auto key){ map.emplace(key, value); });
+    //
+    // Each type used as a value or a key requires specialized to_string and from_string methods. Implementation are
+    // provided for std::string, uint64_t and a couple of types used by pbft. Unfortunately it's not possible to
+    // implement a generic *_string methods for tuples, or even for each tuple arity, as C++ doesn't allow
+    // specialization for (non-concrete) templated types without specializing the entire class template.
+    //
+    template <typename T>
+    class persistent : public persist_base
+    {
+    public:
+        // construct a persistent variable, retrieving its value from storage if it exists, otherwise
+        // initializing it with the provided default.
+        template <typename... K>
+        persistent(std::shared_ptr<bzn::storage_base> persist_storage, const T &default_value, const std::string& name, K... subkeys)
+            : storage(persist_storage), key(escape(name) + generate_key(subkeys...))
+        {
+            if (this->storage)
+            {
+                auto val = this->storage->read(STATE_UUID, this->key);
+                if (val)
+                {
+                    t = from_string(val.value());
+                }
+                else
+                {
+                    t = default_value;
+                    auto result = this->storage->create(STATE_UUID, this->key, to_string(t));
+                    if (result != storage_result::ok)
+                    {
+                        throw std::runtime_error("Error initializing value in storage");
+                    }
+                }
+            }
+            else
+            {
+                throw std::runtime_error("No persistent storage defined");
+            }
+        }
+
+        // conversion constructor for comparison in maps etc. without placing in storage
+        // made explicit to avoid unintentionally assign a raw type to a persistent
+        explicit persistent(const T &value)
+        : t(value)
+        {}
+
+        // default constructor to allow use of [] and insert_or_assign in maps, etc.
+        persistent()
+        {}
+
+        // assign a new value to a persistent variable. the new value is immediately placed in storage
+        persistent<T>& operator=(const T& value)
+        {
+            t = value;
+            if (this->storage)
+            {
+                this->storage->update(STATE_UUID, this->key, to_string(value));
+            }
+            else
+            {
+                throw(std::runtime_error("Object has no storage"));
+            }
+
+            return *this;
+        }
+
+        // since the lifetime of the value is not tied to the object, it's necessary to explicitly
+        // destroy it in order to remove from storage
+        void destroy()
+        {
+            if (this->storage)
+            {
+                this->storage->remove(STATE_UUID, this->key);
+            }
+            else
+            {
+                throw(std::runtime_error("Object has no storage"));
+            }
+        }
+
+        // get the value of the variable
+        const T& value() const
+        {
+            return t;
+        }
+
+        // comparison operator, mainly for ordering in collections
+        bool operator<(const persistent<T>& rhs) const
+        {
+            return t < rhs.t;
+        }
+
+        // test for equality
+        bool operator==(const persistent<T>& rhs) const
+        {
+            return t == rhs.t;
+        }
+
+        static T from_string(const std::string& /*value*/)
+        {
+            // this method needs to be specialized for each type used
+            assert(0);
+            return T{};
+        }
+
+        static std::string to_string(const T& /*value*/)
+        {
+            // this method needs to be specialized for each type used
+            assert(0);
+            return std::string{};
+        }
+
+        // initialize values in a collection
+        template<typename A>
+        static void
+        initialize(std::shared_ptr<bzn::storage_base> storage, const std::string& basename
+            , std::function<void(const persistent<T>&, const A&)> store)
+        {
+            auto escaped_base = escape(basename);
+            auto results = storage->get_keys_if(STATE_UUID, escaped_base + std::string{SEPARATOR}
+                , escaped_base + std::string{SEPARATOR + 1});
+            for (const auto& res : results)
+            {
+                std::string key_str = unescape(res.substr(escaped_base.size() + 1));
+                A key{persistent<A>::from_string(key_str)};
+
+                LOG(debug) << "initializing state " << res << " from storage";
+
+                // instantiate this member from storage and pass it to be emplaced into container
+                store(persistent<T>{storage, {}, basename, key}, key);
+            }
+        }
+
+        // initialize values in a nested collection
+        // note - we need a version of this function for each number of sub-keys
+        template<typename A, typename B>
+        static void
+        initialize(std::shared_ptr<bzn::storage_base> storage, const std::string& basename
+            , std::function<void(const persistent<T>&, const A&, const B&)> store)
+        {
+            auto escaped_base = escape(basename);
+            auto results = storage->get_keys_if(STATE_UUID, escaped_base + std::string{SEPARATOR}
+                , escaped_base + std::string{SEPARATOR + 1});
+            for (const auto& res : results)
+            {
+                std::tuple<A, B> subkeys = extract_subkeys<A, B>(res.substr(escaped_base.size() + 1));
+
+                LOG(debug) << "initializing state " << res << " from storage";
+
+                // instantiate this member from storage and pass it to be emplaced into container
+                store(persistent<T>{storage, {}, basename, std::get<0>(subkeys), std::get<1>(subkeys)}
+                    , std::get<0>(subkeys), std::get<1>(subkeys));
+            }
+        }
+
+        // note - this could be expanded into a variadic to support an arbitrary number of sub-keys
+        template<typename A, typename B>
+        static std::tuple<A, B>
+        extract_subkeys(const std::string& key)
+        {
+            // find unescaped separator
+            size_t offset{0};
+            while (offset < key.size())
+            {
+                offset = key.find(SEPARATOR, offset);
+                if (offset >= key.size() || key[offset + 1] != SEPARATOR)
+                {
+                    break;
+                }
+
+                offset += 2;
+            }
+
+            assert(offset < key.size());
+            std::string v0 = key.substr(0, offset);
+            std::string v1 = key.substr(offset + 1);
+            return {persistent<A>::from_string(unescape(v0)), persistent<B>::from_string(unescape(v1))};
+        }
+
+    private:
+        T t;
+        std::shared_ptr<bzn::storage_base> storage;
+        std::string key;
+
+        std::string generate_key()
+        {
+            return "";
+        }
+
+        template <typename K, typename... Rest>
+        std::string generate_key(K k, Rest... rest)
+        {
+            return std::string{SEPARATOR} + escape(persistent<K>::to_string(k)) + generate_key(rest...);
+        }
+    };
+}

--- a/pbft/test/CMakeLists.txt
+++ b/pbft/test/CMakeLists.txt
@@ -13,7 +13,8 @@ set(test_srcs
     database_pbft_service_test.cpp
     pbft_proto_test.cpp
     pbft_newview_test.cpp
+    pbft_persistent_state_test.cpp
     pbft_viewchange_test.cpp)
-set(test_libs pbft pbft_operations crypto options ${Protobuf_LIBRARIES} bootstrap storage)
+set(test_libs pbft pbft_operations crypto options ${Protobuf_LIBRARIES} bootstrap storage ${ROCKSDB_LIBRARIES})
 
 add_gmock_test(pbft)

--- a/pbft/test/pbft_config_store_test.cpp
+++ b/pbft/test/pbft_config_store_test.cpp
@@ -14,6 +14,8 @@
 #include <gtest/gtest.h>
 #include <include/bluzelle.hpp>
 #include <pbft/pbft_config_store.hpp>
+#include <storage/mem_storage.hpp>
+#include <pbft/pbft.hpp>
 
 using namespace ::testing;
 
@@ -29,6 +31,12 @@ namespace bzn
     class pbft_config_store_test : public Test
     {
     public:
+        pbft_config_store_test()
+        : storage(std::make_shared<bzn::mem_storage>())
+        , store(storage)
+        {}
+
+        std::shared_ptr<bzn::storage_base> storage;
         bzn::pbft_config_store store;
     };
 

--- a/pbft/test/pbft_join_leave_test.cpp
+++ b/pbft/test/pbft_join_leave_test.cpp
@@ -682,6 +682,7 @@ namespace bzn
                 , this->mock_failure_detector
                 , this->crypto
                 , this->operation_manager
+                , this->storage
                 );
         this->pbft->set_audit_enabled(false);
         EXPECT_NO_THROW({
@@ -702,6 +703,7 @@ namespace bzn
                 , this->mock_failure_detector
                 , this->crypto
                 , this->operation_manager
+                , this->storage
         );
         this->pbft->set_audit_enabled(false);
         EXPECT_THROW({this->pbft->start(); }, std::runtime_error);

--- a/pbft/test/pbft_join_leave_test.cpp
+++ b/pbft/test/pbft_join_leave_test.cpp
@@ -365,7 +365,8 @@ namespace bzn
         auto join_retry_timer2 = std::make_unique<NiceMock<bzn::asio::Mocksteady_timer_base >>();
         auto mock_service2 = std::make_shared<NiceMock<bzn::mock_pbft_service_base>>();
         auto mock_options = std::make_shared<bzn::mock_options_base>();
-        auto manager2 = std::make_shared<bzn::pbft_operation_manager>();
+        auto storage2 = std::make_shared<bzn::mem_storage>();
+        auto manager2 = std::make_shared<bzn::pbft_operation_manager>(storage2);
         EXPECT_CALL(*(mock_io_context2), make_unique_steady_timer())
             .Times(AtMost(3)).WillOnce(Invoke([&](){return std::move(audit_heartbeat_timer2);}))
             .WillOnce(Invoke([&](){return std::move(new_config_timer2);}))
@@ -373,7 +374,7 @@ namespace bzn
         EXPECT_CALL(*mock_options, get_uuid()).WillRepeatedly(Return("uuid2"));
         EXPECT_CALL(*mock_options, get_simple_options()).WillRepeatedly(ReturnRef(this->options->get_simple_options()));
         auto pbft2 = std::make_shared<bzn::pbft>(mock_node2, mock_io_context2, TEST_PEER_LIST, mock_options, mock_service2,
-            this->mock_failure_detector, this->crypto, manager2);
+            this->mock_failure_detector, this->crypto, manager2, storage2);
         pbft2->set_audit_enabled(false);
         pbft2->start();
 
@@ -484,7 +485,8 @@ namespace bzn
         auto join_retry_timer3 = std::make_unique<NiceMock<bzn::asio::Mocksteady_timer_base >>();
         auto mock_service3 = std::make_shared<NiceMock<bzn::mock_pbft_service_base>>();
         auto mock_options3 = std::make_shared<bzn::mock_options_base>();
-        auto manager3 = std::make_shared<bzn::pbft_operation_manager>();
+        auto storage3 = std::make_shared<bzn::mem_storage>();
+        auto manager3 = std::make_shared<bzn::pbft_operation_manager>(storage3);
         EXPECT_CALL(*(mock_io_context3), make_unique_steady_timer())
             .Times(AtMost(3)).WillOnce(Invoke([&](){return std::move(audit_heartbeat_timer3);}))
             .WillOnce(Invoke([&](){return std::move(new_config_timer3);}))
@@ -492,7 +494,7 @@ namespace bzn
         EXPECT_CALL(*mock_options3, get_uuid()).WillRepeatedly(Return("uuid3"));
         EXPECT_CALL(*mock_options3, get_simple_options()).WillRepeatedly(ReturnRef(this->options->get_simple_options()));
         auto pbft3 = std::make_shared<bzn::pbft>(mock_node3, mock_io_context3, TEST_PEER_LIST, mock_options3, mock_service3,
-            this->mock_failure_detector, this->crypto, manager3);
+            this->mock_failure_detector, this->crypto, manager3, storage3);
         pbft3->set_audit_enabled(false);
         pbft3->start();
 

--- a/pbft/test/pbft_newview_test.cpp
+++ b/pbft/test/pbft_newview_test.cpp
@@ -100,7 +100,7 @@ namespace bzn
 
         EXPECT_EQ(PBFT_MSG_NEWVIEW, newview.type());
         EXPECT_EQ(new_view_index, newview.view());
-        EXPECT_EQ(this->pbft->next_issued_sequence_number, current_sequence + 1);
+        EXPECT_EQ(this->pbft->next_issued_sequence_number.value(), current_sequence + 1);
     }
 
     TEST_F(pbft_newview_test, test_get_primary)
@@ -110,7 +110,7 @@ namespace bzn
         // the pbft sut must be the current view's primay
         EXPECT_EQ(this->uuid, this->pbft->get_primary().uuid);
 
-        this->pbft->view++;
+        this->pbft->view = this->pbft->view.value() + 1;
         EXPECT_FALSE(this->uuid == this->pbft->get_primary().uuid);
 
         // given a view, get_primary must provide the address of a primary

--- a/pbft/test/pbft_persistent_state_test.cpp
+++ b/pbft/test/pbft_persistent_state_test.cpp
@@ -39,18 +39,22 @@ namespace bzn
         EXPECT_EQ(value2.value(), 10u);
     }
 
+    TEST_F(persistent_state_test, uninitialized_map_generates_exception)
+    {
+        std::map<uint64_t, persistent<std::string>> m;
+        EXPECT_THROW(m.insert({1u, {this->storage, "one", std::string("m"), static_cast<uint64_t>(1)}}), std::runtime_error);
+    }
+
     TEST_F(persistent_state_test, test_initialize)
     {
         std::map<uint64_t, persistent<std::string>> m;
+        persistent<std::string>::init_kv_container<uint64_t>(this->storage, "m", m);
 
         m.insert({1u, {this->storage, "one", std::string("m"), static_cast<uint64_t>(1)}});
         m.insert({2u, {this->storage, "two", std::string("m"), static_cast<uint64_t>(2)}});
 
         std::map<uint64_t, persistent<std::string>> m2;
-        persistent<std::string>::initialize<uint64_t>(this->storage, "m", [&m2](auto value, auto key)
-        {
-            m2.emplace(key, value);
-        });
+        persistent<std::string>::init_kv_container<uint64_t>(this->storage, "m", m2);
 
         EXPECT_EQ(m, m2);
     }
@@ -58,16 +62,13 @@ namespace bzn
     TEST_F(persistent_state_test, test_initialize_nested)
     {
         std::map<uint64_t, std::map<uint64_t, persistent<std::string>>> m;
+        persistent<std::string>::init_kv_container2<uint64_t, uint64_t>(this->storage, "m", m);
 
         m[1].insert({3u, {this->storage, "one", std::string("m"), static_cast<uint64_t>(3), static_cast<uint64_t>(1)}});
         m[2].insert({4u, {this->storage, "two", std::string("m"), static_cast<uint64_t>(4), static_cast<uint64_t>(2)}});
 
         std::map<uint64_t, std::map<uint64_t, persistent<std::string>>> m2;
-        persistent<std::string>::initialize<uint64_t, uint64_t>(this->storage, "m", [&m2](auto value, auto key1, auto key2)
-        {
-            m2[key2].emplace(key1, value);
-        });
-
+        persistent<std::string>::init_kv_container2<uint64_t, uint64_t>(this->storage, "m", m2);
 
         EXPECT_EQ(m, m2);
     }
@@ -75,18 +76,32 @@ namespace bzn
     TEST_F(persistent_state_test, test_escaping)
     {
         std::map<uint64_t, std::map<std::string, persistent<std::string>>> m;
+        persistent<std::string>::init_kv_container2<std::string, uint64_t>(this->storage
+            , std::string{"m"} + ESCAPE_1 + "1", m);
 
-        m[1].insert({"test/one", {this->storage, "one", std::string("m/1"), std::string{"test/one"}, static_cast<uint64_t>(1)}});
-        m[2].insert({"test/two", {this->storage, "two", std::string("m/1"), std::string{"test/two"}, static_cast<uint64_t>(2)}});
+        // m[1].insert({"test/one", {this->storage, "one", std::string("m/1"), std::string{"test/one"}, static_cast<uint64_t>(1)}});
+        m[1].insert({std::string{"test"} + ESCAPE_1 + "one", {this->storage, "one", std::string{"m"} + ESCAPE_1 + "1"
+            , std::string{"test"} + ESCAPE_1 + "one", static_cast<uint64_t>(1)}});
+        m[2].insert({std::string{"test"} + ESCAPE_1 + "two", {this->storage, "two", std::string{"m"} + ESCAPE_1 + "1"
+            , std::string{"test"} + ESCAPE_1 + "two", static_cast<uint64_t>(2)}});
 
         std::map<uint64_t, std::map<std::string, persistent<std::string>>> m2;
-        persistent<std::string>::initialize<std::string, uint64_t>(this->storage, "m/1", [&m2](auto value, auto key1, auto key2)
-        {
-            m2[key2].emplace(key1, value);
-        });
-
+        persistent<std::string>::init_kv_container2<std::string, uint64_t>(this->storage
+            , std::string{"m"} + ESCAPE_1 + "1", m2);
 
         EXPECT_EQ(m, m2);
+
+        auto key1 = persistent<std::string>::generate_key(std::string{"hello"} + ESCAPE_1, std::string{"world"});
+        auto key2 = persistent<std::string>::generate_key(std::string{"hello"}, std::string{ESCAPE_1} + "world");
+        EXPECT_NE(key1, key2);
+
+        std::string subkey1{ESCAPE_1};
+        std::string subkey2{std::string{ESCAPE_2} + "x"};
+        auto key_res = persistent<std::string>::generate_key(subkey1, subkey2);
+        auto extracted = persistent<std::string>::extract_subkeys<std::string
+            , std::string>(key_res.substr(SEPARATOR.size()));
+        EXPECT_EQ(subkey1, std::get<0>(extracted));
+        EXPECT_EQ(subkey2, std::get<1>(extracted));
     }
 
     TEST_F(persistent_state_test, test_physical_storage)
@@ -97,7 +112,9 @@ namespace bzn
             auto phys_storage = std::make_shared<bzn::rocksdb_storage>("./", "utest", NODE_UUID);
             persistent<uint64_t> int_value(phys_storage, 10u, "int_value");
             persistent<std::string> str_value(phys_storage, "my_value", "str_value");
+
             std::map<uint64_t, persistent<std::string>> map_value;
+            persistent<std::string>::init_kv_container<uint64_t>(phys_storage, "map_value", map_value);
             map_value[1] = {phys_storage, "one", "map_value", uint64_t{1u}};
             map_value[2] = {phys_storage, "two", "map_value", uint64_t{2u}};
             map_value[10] = {phys_storage, "ten", "map_value", uint64_t{10u}};
@@ -109,12 +126,9 @@ namespace bzn
             EXPECT_EQ(int_value.value(), 10u);
             persistent<std::string> str_value(phys_storage, "", "str_value");
             EXPECT_EQ(str_value.value(), "my_value");
-            std::map<uint64_t, persistent<std::string>> map_value;
-            persistent<std::string>::initialize<uint64_t>(phys_storage, "map_value", [&map_value](auto value, auto key)
-            {
-                map_value.emplace(key, value);
-            });
 
+            std::map<uint64_t, persistent<std::string>> map_value;
+            persistent<std::string>::init_kv_container<uint64_t>(phys_storage, "map_value", map_value);
             EXPECT_EQ(map_value[1].value(), "one");
             EXPECT_EQ(map_value[2].value(), "two");
             EXPECT_EQ(map_value[10].value(), "ten");
@@ -122,5 +136,38 @@ namespace bzn
         }
 
         system(std::string("rm -r -f " + NODE_UUID).c_str());
+    }
+
+    TEST_F(persistent_state_test, test_conversions)
+    {
+        std::string str1{"This is a test"};
+        std::string str1_1{persistent<std::string>::to_string(str1)};
+        std::string str1_2{persistent<std::string>::from_string(str1)};
+        EXPECT_EQ(str1, str1_1);
+        EXPECT_EQ(str1, str1_2);
+
+        bzn::log_key_t log_key{1u, 2u};
+        std::string log_key_1{persistent<bzn::log_key_t>::to_string(log_key)};
+        bzn::log_key_t log_key_2{persistent<bzn::log_key_t>::from_string(log_key_1)};
+        EXPECT_EQ(log_key, log_key_2);
+
+        bzn::operation_key_t operation_key{1u, 2u, "hash"};
+        std::string operation_key_1{persistent<bzn::operation_key_t>::to_string(operation_key)};
+        bzn::operation_key_t operation_key_2{persistent<bzn::operation_key_t>::from_string(operation_key_1)};
+        EXPECT_EQ(operation_key, operation_key_2);
+
+        bzn::checkpoint_t checkpoint{1u, "hash"};
+        std::string checkpoint_1{persistent<bzn::checkpoint_t>::to_string(checkpoint)};
+        bzn::checkpoint_t checkpoint_2{persistent<bzn::checkpoint_t>::from_string(checkpoint_1)};
+        EXPECT_EQ(checkpoint, checkpoint_2);
+    }
+
+    TEST_F(persistent_state_test, test_forked_alias_generates_exception)
+    {
+        persistent<std::string> str{this->storage, "test", "test_key"};
+        persistent<std::string> str2{this->storage, "test2", "test_key"};
+        EXPECT_EQ(str2.value(), "test");
+        str2 = "test2";
+        EXPECT_THROW(str = "test", std::runtime_error);
     }
 }

--- a/pbft/test/pbft_persistent_state_test.cpp
+++ b/pbft/test/pbft_persistent_state_test.cpp
@@ -1,0 +1,126 @@
+// Copyright (C) 2018 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+
+#include <pbft/test/pbft_test_common.hpp>
+#include <pbft/pbft_persistent_state.hpp>
+#include <storage/mem_storage.hpp>
+#include <storage/rocksdb_storage.hpp>
+
+using namespace ::testing;
+
+namespace
+{
+    const bzn::uuid_t NODE_UUID = "d1e04722-41f0-4c43-a6c0-86a9e62a88e3";
+}
+namespace bzn
+{
+    class persistent_state_test : public Test
+    {
+    public:
+        std::shared_ptr<bzn::storage_base> storage = std::make_shared<bzn::mem_storage>();
+    };
+
+    TEST_F(persistent_state_test, test_assignment)
+    {
+        persistent<uint64_t> value(this->storage, uint64_t{}, "value");
+        value = 10u;
+
+        persistent<uint64_t> value2(this->storage, uint64_t{}, "value");
+        EXPECT_EQ(value2.value(), 10u);
+    }
+
+    TEST_F(persistent_state_test, test_initialize)
+    {
+        std::map<uint64_t, persistent<std::string>> m;
+
+        m.insert({1u, {this->storage, "one", std::string("m"), static_cast<uint64_t>(1)}});
+        m.insert({2u, {this->storage, "two", std::string("m"), static_cast<uint64_t>(2)}});
+
+        std::map<uint64_t, persistent<std::string>> m2;
+        persistent<std::string>::initialize<uint64_t>(this->storage, "m", [&m2](auto value, auto key)
+        {
+            m2.emplace(key, value);
+        });
+
+        EXPECT_EQ(m, m2);
+    }
+
+    TEST_F(persistent_state_test, test_initialize_nested)
+    {
+        std::map<uint64_t, std::map<uint64_t, persistent<std::string>>> m;
+
+        m[1].insert({3u, {this->storage, "one", std::string("m"), static_cast<uint64_t>(3), static_cast<uint64_t>(1)}});
+        m[2].insert({4u, {this->storage, "two", std::string("m"), static_cast<uint64_t>(4), static_cast<uint64_t>(2)}});
+
+        std::map<uint64_t, std::map<uint64_t, persistent<std::string>>> m2;
+        persistent<std::string>::initialize<uint64_t, uint64_t>(this->storage, "m", [&m2](auto value, auto key1, auto key2)
+        {
+            m2[key2].emplace(key1, value);
+        });
+
+
+        EXPECT_EQ(m, m2);
+    }
+
+    TEST_F(persistent_state_test, test_escaping)
+    {
+        std::map<uint64_t, std::map<std::string, persistent<std::string>>> m;
+
+        m[1].insert({"test/one", {this->storage, "one", std::string("m/1"), std::string{"test/one"}, static_cast<uint64_t>(1)}});
+        m[2].insert({"test/two", {this->storage, "two", std::string("m/1"), std::string{"test/two"}, static_cast<uint64_t>(2)}});
+
+        std::map<uint64_t, std::map<std::string, persistent<std::string>>> m2;
+        persistent<std::string>::initialize<std::string, uint64_t>(this->storage, "m/1", [&m2](auto value, auto key1, auto key2)
+        {
+            m2[key2].emplace(key1, value);
+        });
+
+
+        EXPECT_EQ(m, m2);
+    }
+
+    TEST_F(persistent_state_test, test_physical_storage)
+    {
+        system(std::string("rm -r -f " + NODE_UUID).c_str());
+
+        {
+            auto phys_storage = std::make_shared<bzn::rocksdb_storage>("./", "utest", NODE_UUID);
+            persistent<uint64_t> int_value(phys_storage, 10u, "int_value");
+            persistent<std::string> str_value(phys_storage, "my_value", "str_value");
+            std::map<uint64_t, persistent<std::string>> map_value;
+            map_value[1] = {phys_storage, "one", "map_value", uint64_t{1u}};
+            map_value[2] = {phys_storage, "two", "map_value", uint64_t{2u}};
+            map_value[10] = {phys_storage, "ten", "map_value", uint64_t{10u}};
+        }
+
+        {
+            auto phys_storage = std::make_shared<bzn::rocksdb_storage>("./", "utest", NODE_UUID);
+            persistent<uint64_t> int_value(phys_storage, 0, "int_value");
+            EXPECT_EQ(int_value.value(), 10u);
+            persistent<std::string> str_value(phys_storage, "", "str_value");
+            EXPECT_EQ(str_value.value(), "my_value");
+            std::map<uint64_t, persistent<std::string>> map_value;
+            persistent<std::string>::initialize<uint64_t>(phys_storage, "map_value", [&map_value](auto value, auto key)
+            {
+                map_value.emplace(key, value);
+            });
+
+            EXPECT_EQ(map_value[1].value(), "one");
+            EXPECT_EQ(map_value[2].value(), "two");
+            EXPECT_EQ(map_value[10].value(), "ten");
+
+        }
+
+        system(std::string("rm -r -f " + NODE_UUID).c_str());
+    }
+}

--- a/pbft/test/pbft_test_common.cpp
+++ b/pbft/test/pbft_test_common.cpp
@@ -137,6 +137,7 @@ namespace bzn::test
                 , this->mock_failure_detector
                 , this->crypto
                 , this->operation_manager
+                , this->storage
         );
         this->pbft->set_audit_enabled(false);
         this->pbft->start();

--- a/pbft/test/pbft_viewchange_test.cpp
+++ b/pbft/test/pbft_viewchange_test.cpp
@@ -351,8 +351,11 @@ namespace bzn
 
         EXPECT_CALL(*mock_options, get_uuid()).WillRepeatedly(Invoke([](){return "uuid2";}));
 
-        auto manager2 = std::make_shared<bzn::pbft_operation_manager>();
-        auto pbft2 = std::make_shared<bzn::pbft>(mock_node2, mock_io_context2, TEST_PEER_LIST, mock_options, mock_service2, this->mock_failure_detector, this->crypto, manager2);
+        auto storage2 = std::make_shared<bzn::mem_storage>();
+        auto manager2 = std::make_shared<bzn::pbft_operation_manager>(storage2);
+
+        auto pbft2 = std::make_shared<bzn::pbft>(mock_node2, mock_io_context2, TEST_PEER_LIST, mock_options, mock_service2
+            , this->mock_failure_detector, this->crypto, manager2, storage2);
         pbft2->set_audit_enabled(false);
 
         pbft2->start();
@@ -416,8 +419,8 @@ namespace bzn
         // get sut1 to generate viewchange message
         this->pbft->handle_failure();
 
-        EXPECT_EQ(this->pbft->view, 2U);
-        EXPECT_EQ(pbft2->next_issued_sequence_number, 103U);
+        EXPECT_EQ(this->pbft->view.value(), 2U);
+        EXPECT_EQ(pbft2->next_issued_sequence_number.value(), 103U);
     }
 
     TEST_F(pbft_viewchange_test, is_valid_viewchange_does_not_throw_if_no_checkpoint_yet)

--- a/storage/rocksdb_storage.cpp
+++ b/storage/rocksdb_storage.cpp
@@ -307,13 +307,6 @@ rocksdb_storage::get_snapshot()
 bool
 rocksdb_storage::load_snapshot(const std::string& data)
 {
-    if (!boost::filesystem::exists(this->snapshot_file))
-    {
-        LOG(error) << "no snapshot found";
-
-        return false;
-    }
-
     std::lock_guard<std::shared_mutex> lock(this->lock); // lock for write access
 
     const std::string tmp_snapshot(this->snapshot_file + ".tmp");

--- a/swarm/main.cpp
+++ b/swarm/main.cpp
@@ -280,7 +280,7 @@ main(int argc, const char* argv[])
 
         auto pbft = std::make_shared<bzn::pbft>(node, io_context, peers.get_peers(), options,
             std::make_shared<bzn::database_pbft_service>(io_context, unstable_storage, crud, options->get_uuid())
-            ,failure_detector , crypto, operation_manager);
+            ,failure_detector , crypto, operation_manager, unstable_storage);
 
         pbft->set_audit_enabled(options->get_simple_options().get<bool>(bzn::option_names::AUDIT_ENABLED));
 


### PR DESCRIPTION
Persistently stored variable framework and usage in PBFT.

I recommend reading the block comment in pbft_persistent_storage.hpp first. The intention was to hide all the complexity in there and make using the variables as easy as possible, but there are a couple of scenarios that are a little tricky.

