### PR TITLE
KEP-1088: Ignore name field in join requests. Don't re-execute new_co…

### DIFF
--- a/pbft/pbft_configuration.cpp
+++ b/pbft/pbft_configuration.cpp
@@ -19,6 +19,7 @@
 #include <numeric>
 #include <iterator>
 #include <functional>
+#include <boost/format.hpp>
 
 using namespace bzn;
 
@@ -196,15 +197,18 @@ pbft_configuration::conflicting_peer_exists(const bzn::peer_address_t &peer) con
 {
     for (auto& p : this->peers)
     {
-        if (p.uuid == peer.uuid || p.name == peer.name)
+        if (p.uuid == peer.uuid)
         {
+            LOG(debug) << "rejecting peer with duplicate uuid: " << peer.uuid;
             return true;
         }
 
         if (p.host == peer.host)
         {
-            if (p.port == peer.port || p.http_port == peer.http_port)
+            if (p.port == peer.port)
             {
+                LOG(debug) << boost::format("rejecting peer with duplicate port: %1%/%2%")
+                              % p.port % peer.port;
                 return true;
             }
         }
@@ -216,7 +220,7 @@ pbft_configuration::conflicting_peer_exists(const bzn::peer_address_t &peer) con
 bool
 pbft_configuration::valid_peer(const bzn::peer_address_t &peer) const
 {
-    if (peer.name.empty() || peer.uuid.empty() || peer.host.empty() || !peer.port || !peer.http_port)
+    if (peer.uuid.empty() || peer.host.empty() || !peer.port)
     {
         return false;
     }

--- a/pbft/test/pbft_configuration_test.cpp
+++ b/pbft/test/pbft_configuration_test.cpp
@@ -104,18 +104,14 @@ namespace
 
     TEST_F(pbft_configuration_test, reject_invalid_peer)
     {
-        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("", 8081, 8881, "name1", "uuid1")));
-        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 0, 8881, "name1", "uuid1")));
-        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 0, "name1", "uuid1")));
-        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 8881, "", "uuid1")));
-        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 8881, "name1", "")));
-        EXPECT_TRUE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 8881, "name1", "uuid1")));
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("", 8081, 0, "", "uuid1")));
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 0, 0, "", "uuid1")));
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 0, "", "")));
+        EXPECT_TRUE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 0, "", "uuid1")));
 
-        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8082, 8882, "name2", "uuid1")));
-        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8082, 8882, "name1", "uuid2")));
-        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8082, 8881, "name2", "uuid2")));
-        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 8882, "name2", "uuid2")));
-        EXPECT_TRUE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8082, 8882, "name2", "uuid2")));
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8082, 0, "", "uuid1")));
+        EXPECT_FALSE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8081, 0, "", "uuid2")));
+        EXPECT_TRUE(this->cfg.add_peer(bzn::peer_address_t("127.0.0.1", 8082, 0, "", "uuid2")));
     }
 
     TEST_F(pbft_configuration_test, diff_test)


### PR DESCRIPTION
…nfig messages after viewchange

A couple of small changes to fix bug with dynamic peering