### PR TITLE
Fixes for a couple of bugs:

### DIFF
--- a/crypto/crypto.cpp
+++ b/crypto/crypto.cpp
@@ -168,11 +168,6 @@ crypto::verify(const bzn_envelope& msg)
 bool
 crypto::sign(bzn_envelope& msg)
 {
-    if (!this->options->get_simple_options().get<bool>(bzn::option_names::CRYPTO_ENABLED_OUTGOING))
-    {
-        return true;
-    }
-
     if (msg.sender().empty())
     {
         msg.set_sender(this->options->get_uuid());
@@ -182,6 +177,11 @@ crypto::sign(bzn_envelope& msg)
     {
         LOG(error) << "Cannot sign message purportedly sent by " << msg.sender();
         return false;
+    }
+
+    if (!this->options->get_simple_options().get<bool>(bzn::option_names::CRYPTO_ENABLED_OUTGOING))
+    {
+        return true;
     }
 
     const auto msg_text = this->deterministic_serialize(msg);

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -193,7 +193,7 @@ namespace bzn
         void notify_audit_failure_detected();
 
         void checkpoint_reached_locally(uint64_t sequence);
-        void maybe_stabilize_checkpoint(const checkpoint_t& cp);
+        void maybe_stabilize_checkpoint(checkpoint_t cp);
         void stabilize_checkpoint(const checkpoint_t& cp);
         const peer_address_t& select_peer_for_checkpoint(const checkpoint_t& cp);
         void request_checkpoint_state(const checkpoint_t& cp);

--- a/pbft/test/pbft_join_leave_test.cpp
+++ b/pbft/test/pbft_join_leave_test.cpp
@@ -170,6 +170,16 @@ namespace bzn
             return this->pbft->move_to_new_configuration(config_hash, view);
         }
 
+        void handle_preprepare(const pbft_msg& msg, const bzn_envelope& original_msg)
+        {
+            return this->pbft->handle_preprepare(msg, original_msg);
+        }
+
+        void handle_prepare(const pbft_msg& msg, const bzn_envelope& original_msg)
+        {
+            return this->pbft->handle_prepare(msg, original_msg);
+        }
+
         void handle_commit(const pbft_msg& msg, const bzn_envelope& original_msg)
         {
             return this->pbft->handle_commit(msg, original_msg);
@@ -567,7 +577,7 @@ namespace bzn
                             .Times(Exactly(TEST_PEER_LIST.size()));
 
                         // reflect the pre-prepare back
-                        pbft->handle_message(msg, *envelope);
+                        this->handle_preprepare(msg, *envelope);
                     }
 
                     pbft_msg prepare;
@@ -578,7 +588,7 @@ namespace bzn
 
                     auto wmsg2 = wrap_pbft_msg(prepare);
                     wmsg2.set_sender(p.uuid);
-                    pbft->handle_message(prepare, wmsg2);
+                    this->handle_prepare(prepare, wmsg2);
                 }));
         }
 


### PR DESCRIPTION
- messages didn't have sender set if cryto disabled
- missing lock
- corruption of checkpoint stack variable leading to bad water mark
settings in pbft

For the last one - checkpoint just emplace'd passed by reference to function (stabilize_checkpoint) that destroys it (clear_local_checkpoints_until) then uses it to set low_water_mark/high_water_mark, leading to arbitrary watermark values causing subsequent messages to be rejected.
