### PR TITLE
Merge bugfixes to 0.5

### DIFF
--- a/crypto/crypto.cpp
+++ b/crypto/crypto.cpp
@@ -160,11 +160,6 @@ crypto::verify(const bzn_envelope& msg)
 bool
 crypto::sign(bzn_envelope& msg)
 {
-    if (!this->options->get_simple_options().get<bool>(bzn::option_names::CRYPTO_ENABLED_OUTGOING))
-    {
-        return true;
-    }
-
     if (msg.sender().empty())
     {
         msg.set_sender(this->options->get_uuid());
@@ -174,6 +169,11 @@ crypto::sign(bzn_envelope& msg)
     {
         LOG(error) << "Cannot sign message purportedly sent by " << msg.sender();
         return false;
+    }
+
+    if (!this->options->get_simple_options().get<bool>(bzn::option_names::CRYPTO_ENABLED_OUTGOING))
+    {
+        return true;
     }
 
     const auto msg_text = this->deterministic_serialize(msg);

--- a/pbft/database_pbft_service.cpp
+++ b/pbft/database_pbft_service.cpp
@@ -185,6 +185,14 @@ database_pbft_service::get_service_state(uint64_t sequence_number) const
 bool
 database_pbft_service::set_service_state(uint64_t sequence_number, const bzn::service_state_t& data)
 {
+    std::lock_guard<std::mutex> lock(this->lock);
+
+    if (this->next_request_sequence >= sequence_number)
+    {
+        LOG(debug) << "No need to apply service state";
+        return true;
+    }
+
     // initialize database state from checkpoint data
     if (!this->crud->load_state(data))
     {

--- a/pbft/pbft.cpp
+++ b/pbft/pbft.cpp
@@ -188,6 +188,8 @@ pbft::handle_membership_message(const bzn_envelope& msg, std::shared_ptr<bzn::se
 
     const auto hash = this->crypto->hash(msg);
 
+    std::lock_guard<std::mutex> lock(this->pbft_lock);
+
     switch (inner_msg.type())
     {
         case PBFT_MMSG_JOIN:
@@ -212,7 +214,6 @@ pbft::handle_membership_message(const bzn_envelope& msg, std::shared_ptr<bzn::se
 void
 pbft::handle_message(const pbft_msg& msg, const bzn_envelope& original_msg)
 {
-
     LOG(debug) << "Received message: " << msg.ShortDebugString().substr(0, MAX_MESSAGE_SIZE);
 
     if (!this->preliminary_filter_msg(msg))
@@ -267,13 +268,15 @@ pbft::preliminary_filter_msg(const pbft_msg& msg)
 
         if (msg.sequence() <= this->low_water_mark)
         {
-            LOG(debug) << "Dropping message because it has an unreasonable sequence number " << msg.sequence();
+            LOG(debug) << boost::format("Dropping message because sequence number %1% less than %2%") % msg.sequence()
+                % this->low_water_mark;
             return false;
         }
 
         if (msg.sequence() > this->high_water_mark)
         {
-            LOG(debug) << "Dropping message because it has an unreasonable sequence number " << msg.sequence();
+            LOG(debug) << boost::format("Dropping message because sequence number %1% greater than %2%") % msg.sequence()
+                % this->high_water_mark;
             return false;
         }
     }
@@ -934,7 +937,7 @@ pbft::unstable_checkpoints_count() const
 }
 
 void
-pbft::maybe_stabilize_checkpoint(const checkpoint_t& cp)
+pbft::maybe_stabilize_checkpoint(checkpoint_t cp)
 {
     if (this->unstable_checkpoint_proofs[cp].size() < this->quorum_size())
     {

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -191,7 +191,7 @@ namespace bzn
         void notify_audit_failure_detected();
 
         void checkpoint_reached_locally(uint64_t sequence);
-        void maybe_stabilize_checkpoint(const checkpoint_t& cp);
+        void maybe_stabilize_checkpoint(checkpoint_t cp);
         void stabilize_checkpoint(const checkpoint_t& cp);
         const peer_address_t& select_peer_for_checkpoint(const checkpoint_t& cp);
         void request_checkpoint_state(const checkpoint_t& cp);

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -226,7 +226,7 @@ namespace bzn
         void initiate_viewchange();
         pbft_msg make_viewchange(uint64_t new_view, uint64_t n, const std::unordered_map<bzn::uuid_t, persistent<std::string>>& stable_checkpoint_proof, const std::map<uint64_t, std::shared_ptr<bzn::pbft_operation>>& prepared_operations);
         pbft_msg make_newview(uint64_t new_view_index,  const std::map<uuid_t,bzn_envelope>& viewchange_envelopes_from_senders, const std::map<uint64_t, bzn_envelope>& pre_prepare_messages) const;
-        std::pair<pbft_msg, uint64_t> build_newview(uint64_t new_view, const std::map<uuid_t,bzn_envelope>& viewchange_envelopes_from_senders) const;
+        pbft_msg build_newview(uint64_t new_view, const std::map<uuid_t,bzn_envelope>& viewchange_envelopes_from_senders) const;
         std::map<bzn::checkpoint_t , std::set<bzn::uuid_t>> validate_and_extract_checkpoint_hashes(const pbft_msg &viewchange_message) const;
         void save_checkpoint(const pbft_msg& msg);
         void fill_in_missing_pre_prepares(uint64_t max_checkpoint_sequence, uint64_t new_view, std::map<uint64_t, bzn_envelope>& pre_prepares) const;

--- a/pbft/pbft_persistent_state.hpp
+++ b/pbft/pbft_persistent_state.hpp
@@ -18,6 +18,8 @@
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <gtest/gtest_prod.h>
+#include <include/bluzelle.hpp>
+#include <pbft/operations/pbft_operation.hpp>
 
 namespace
 {
@@ -331,4 +333,25 @@ namespace bzn
         }
         FRIEND_TEST(persistent_state_test, test_escaping);
     };
+
+    template<> std::string persistent<std::string>::to_string(const std::string &value);
+    template<> std::string persistent<std::string>::from_string(const std::string &value);
+
+    template<> std::string persistent<bzn::log_key_t>::to_string(const bzn::log_key_t &key);
+    template<> bzn::log_key_t persistent<bzn::log_key_t>::from_string(const std::string &value);
+
+    template<> std::string persistent<bzn::operation_key_t>::to_string(const bzn::operation_key_t &key);
+    template<> bzn::operation_key_t persistent<bzn::operation_key_t>::from_string(const std::string &value);
+
+    template<> std::string persistent<bzn::checkpoint_t>::to_string(const bzn::checkpoint_t &cp);
+    template<> bzn::checkpoint_t persistent<bzn::checkpoint_t>::from_string(const std::string &value);
+
+    template <> std::string persistent<uint64_t>::to_string(const uint64_t& val);
+    template <> uint64_t persistent<uint64_t>::from_string(const std::string& value);
+
+    template<> std::string persistent<bool>::to_string(const bool &val);
+    template<> bool persistent<bool>::from_string(const std::string &value);
+
+    template<> std::string persistent<bzn_envelope>::to_string(const bzn_envelope &val);
+    template<> bzn_envelope persistent<bzn_envelope>::from_string(const std::string &value);
 }

--- a/pbft/test/pbft_join_leave_test.cpp
+++ b/pbft/test/pbft_join_leave_test.cpp
@@ -169,6 +169,16 @@ namespace bzn
             return this->pbft->move_to_new_configuration(config_hash, view);
         }
 
+        void handle_preprepare(const pbft_msg& msg, const bzn_envelope& original_msg)
+        {
+            return this->pbft->handle_preprepare(msg, original_msg);
+        }
+
+        void handle_prepare(const pbft_msg& msg, const bzn_envelope& original_msg)
+        {
+            return this->pbft->handle_prepare(msg, original_msg);
+        }
+
         void handle_commit(const pbft_msg& msg, const bzn_envelope& original_msg)
         {
             return this->pbft->handle_commit(msg, original_msg);
@@ -565,7 +575,7 @@ namespace bzn
                             .Times(Exactly(TEST_PEER_LIST.size()));
 
                         // reflect the pre-prepare back
-                        pbft->handle_message(msg, *envelope);
+                        this->handle_preprepare(msg, *envelope);
                     }
 
                     pbft_msg prepare;
@@ -576,7 +586,7 @@ namespace bzn
 
                     auto wmsg2 = wrap_pbft_msg(prepare);
                     wmsg2.set_sender(p.uuid);
-                    pbft->handle_message(prepare, wmsg2);
+                    this->handle_prepare(prepare, wmsg2);
                 }));
         }
 

--- a/pbft/test/pbft_persistent_state_test.cpp
+++ b/pbft/test/pbft_persistent_state_test.cpp
@@ -124,7 +124,7 @@ namespace bzn
 
     TEST_F(persistent_state_test, test_physical_storage)
     {
-        system(std::string("rm -r -f " + NODE_UUID).c_str());
+        if (system(std::string("rm -r -f " + NODE_UUID).c_str())) {}
 
         {
             auto phys_storage = std::make_shared<bzn::rocksdb_storage>("./", "utest", NODE_UUID);
@@ -153,7 +153,7 @@ namespace bzn
 
         }
 
-        system(std::string("rm -r -f " + NODE_UUID).c_str());
+        if (system(std::string("rm -r -f " + NODE_UUID).c_str())) {}
     }
 
     TEST_F(persistent_state_test, test_conversions)
@@ -198,6 +198,8 @@ namespace bzn
         persistent<std::string> str2{this->storage, "test2", "test_key"};
         EXPECT_EQ(str2.value(), "test");
         str2 = "test2";
+#ifndef NDEBUG
         EXPECT_THROW(str = "test", std::runtime_error);
+#endif
     }
 }

--- a/pbft/test/pbft_viewchange_test.cpp
+++ b/pbft/test/pbft_viewchange_test.cpp
@@ -420,7 +420,6 @@ namespace bzn
         this->pbft->handle_failure();
 
         EXPECT_EQ(this->pbft->view.value(), 2U);
-        EXPECT_EQ(pbft2->next_issued_sequence_number.value(), 103U);
     }
 
     TEST_F(pbft_viewchange_test, is_valid_viewchange_does_not_throw_if_no_checkpoint_yet)

--- a/storage/test/storage_test.cpp
+++ b/storage/test/storage_test.cpp
@@ -75,7 +75,7 @@ public:
     storageTest()
     {
         // just to be safe...
-        system(std::string("rm -r -f " + NODE_UUID).c_str());
+        if (system(std::string("rm -r -f " + NODE_UUID).c_str())) {}
         this->storage = create_storage<T>();
     }
 
@@ -83,7 +83,7 @@ public:
     {
         // For each run, the database has to be cleared out...
         this->storage.reset();
-        system(std::string("rm -r -f " + NODE_UUID).c_str());
+        if (system(std::string("rm -r -f " + NODE_UUID).c_str())) {}
     }
 
     std::shared_ptr<bzn::storage_base> storage;


### PR DESCRIPTION
Bugfixes from devel to be merged into 0.5 release:
KEP-1231: forward declarations for template specializations (#259)
KEP-1169: Notify failure detector when forwarded join request is executed (#257)
KEP-1236: fix for race condition processing operations (#260)
Fixes for a couple of bugs: (#253)
KEP-1202: update next_sequence number from newview (#258)
