### PR TITLE
KEP-1247 - changed proto to use bytes for state instead of string

### DIFF
--- a/proto/pbft.proto
+++ b/proto/pbft.proto
@@ -90,7 +90,7 @@ message pbft_membership_msg
     string state_hash = 4;
 
     // for set_state
-    string state_data = 5;
+    bytes state_data = 5;
     bzn_envelope newview_msg = 6;
 }
 


### PR DESCRIPTION
One-liner. Fixes issue with being unable to parse payload of state message.