### PR TITLE
KEP-1294: missing lock causing instability of swarm (devel)

### DIFF
--- a/pbft/database_pbft_service.cpp
+++ b/pbft/database_pbft_service.cpp
@@ -58,11 +58,13 @@ database_pbft_service::apply_operation(const std::shared_ptr<bzn::pbft_operation
             // KEP-899 - We do not want to throw a runtime error for duplicates, as it is possible that
             // during a view change we may try to perform duplicate operatiosn that have already been
             // done in previous views.
-            LOG(warning) << "failed to store pbft request, possible duplicate? : " << op->get_database_msg().DebugString() << ", " << uint32_t(result);
+            LOG(warning) << "failed to store pbft request, possible duplicate? : "
+                << op->get_database_msg().DebugString().substr(0, MAX_MESSAGE_SIZE) << ", " << uint32_t(result);
             return;
         }
 
-        LOG(fatal) << "failed to store pbft request: " << op->get_database_msg().DebugString() << ", " << uint32_t(result);
+        LOG(fatal) << "failed to store pbft request: "
+            << op->get_database_msg().DebugString().substr(0, MAX_MESSAGE_SIZE) << ", " << uint32_t(result);
 
         // these are fatal... something bad is going on.
         throw std::runtime_error("Failed to store pbft request! (" + std::to_string(uint8_t(result)) + ")");
@@ -121,7 +123,7 @@ database_pbft_service::process_awaiting_operations()
             throw std::runtime_error("Failed to create pbft_request from database read!");
         }
 
-        LOG(info) << "Executing request " << request.DebugString() << "..., sequence: " << key;
+        LOG(info) << "Executing request " << request.DebugString().substr(0, MAX_MESSAGE_SIZE) << "..., sequence: " << key;
 
         if (auto op_it = this->operations_awaiting_result.find(this->next_request_sequence); op_it != this->operations_awaiting_result.end())
         {

--- a/pbft/pbft.cpp
+++ b/pbft/pbft.cpp
@@ -270,7 +270,7 @@ pbft::preliminary_filter_msg(const pbft_msg& msg)
 
         if (msg.sequence() <= this->low_water_mark)
         {
-            LOG(debug) << boost::format("Dropping message because sequence number %1% less than %2%") % msg.sequence()
+            LOG(debug) << boost::format("Dropping message because sequence number %1% <= %2%") % msg.sequence()
                 % this->low_water_mark;
             return false;
         }
@@ -329,7 +329,7 @@ pbft::handle_request(const bzn_envelope& request_env, const std::shared_ptr<sess
     if (this->already_seen_request(request_env, hash))
     {
         // TODO: send error message to client
-        LOG(info) << "Rejecting duplicate request: " << request_env.ShortDebugString();
+        LOG(info) << "Rejecting duplicate request: " << request_env.ShortDebugString().substr(0, MAX_MESSAGE_SIZE);
         return;
     }
     this->saw_request(request_env, hash);
@@ -1100,6 +1100,8 @@ void
 pbft::handle_database_message(const bzn_envelope& msg, std::shared_ptr<bzn::session_base> session)
 {
     // TODO: timestamp should be set by the client. setting it here breaks the signature (which is correct).
+
+    std::lock_guard<std::mutex> lock(this->pbft_lock);
 
     LOG(debug) << "got database message";
 

--- a/pbft/pbft.cpp
+++ b/pbft/pbft.cpp
@@ -1101,12 +1101,12 @@ pbft::handle_database_message(const bzn_envelope& msg, std::shared_ptr<bzn::sess
 {
     // TODO: timestamp should be set by the client. setting it here breaks the signature (which is correct).
 
-    std::lock_guard<std::mutex> lock(this->pbft_lock);
-
     LOG(debug) << "got database message";
 
     if (!this->service->apply_operation_now(msg, session))
     {
+        std::lock_guard<std::mutex> lock(this->pbft_lock);
+
         if (msg.timestamp() == 0)
         {
             bzn_envelope mutable_msg(msg);


### PR DESCRIPTION
Added a lock to pbft::handle_database_request
Cleaned up a couple of log messages to work better for large db values