### PR TITLE
kep-1144 Add Swarm ID to all swarm<>swarm and swarm<>client messages

### DIFF
--- a/mocks/mock_pbft_base.hpp
+++ b/mocks/mock_pbft_base.hpp
@@ -25,21 +25,21 @@ namespace bzn {
 class Mockpbft_base : public pbft_base {
 public:
     MOCK_METHOD0(start,
-    void());
+            void());
     MOCK_METHOD2(handle_message,
-    void(const pbft_msg& msg, const bzn_envelope& original_msg));
+            void(const pbft_msg& msg, const bzn_envelope& original_msg));
     MOCK_METHOD2(handle_database_message,
-    void(const bzn_envelope& msg, std::shared_ptr<bzn::session_base> session));
+            void(const bzn_envelope& msg, std::shared_ptr<bzn::session_base> session));
     MOCK_CONST_METHOD0(is_primary,
-    bool());
+            bool());
     MOCK_CONST_METHOD1(get_primary,
-    const peer_address_t&(std::optional<uint64_t> view));
+            const peer_address_t&(std::optional<uint64_t> view));
     MOCK_CONST_METHOD0(get_uuid,
-    const bzn::uuid_t&());
+            const bzn::uuid_t&());
     MOCK_METHOD0(handle_failure,
-    void());
+            void());
     MOCK_CONST_METHOD1(get_peer_by_uuid,
-    const peer_address_t&(const std::string& uuid));
+            const peer_address_t&(const std::string& uuid));
     MOCK_CONST_METHOD0(current_peers_ptr,
         std::shared_ptr<const std::vector<bzn::peer_address_t>>());
 };

--- a/node/session.cpp
+++ b/node/session.cpp
@@ -28,7 +28,8 @@ session::session(
         std::chrono::milliseconds ws_idle_timeout,
         std::list<bzn::session_shutdown_handler> shutdown_handlers,
         std::shared_ptr<bzn::crypto_base> crypto,
-        std::shared_ptr<bzn::monitor_base> monitor
+        std::shared_ptr<bzn::monitor_base> monitor,
+        std::shared_ptr<bzn::options_base> options
 )
         : session_id(session_id)
         , ep(std::move(ep))
@@ -42,6 +43,7 @@ session::session(
         , write_buffer(nullptr, 0)
         , crypto(std::move(crypto))
         , monitor(std::move(monitor))
+        , options(std::move(options))
 {
     LOG(debug) << "creating session " << std::to_string(session_id);
 }
@@ -268,6 +270,7 @@ session::do_write()
 void
 session::send_signed_message(std::shared_ptr<bzn_envelope> msg)
 {
+    msg->set_swarm_id(this->options->get_swarm_id());
     if (msg->signature().empty())
     {
         this->crypto->sign(*msg);

--- a/node/session.hpp
+++ b/node/session.hpp
@@ -42,7 +42,8 @@ namespace bzn
                 std::chrono::milliseconds ws_idle_timeout,
                 std::list<bzn::session_shutdown_handler> shutdown_handlers,
                 std::shared_ptr<bzn::crypto_base> crypto,
-                std::shared_ptr<bzn::monitor_base> monitor);
+                std::shared_ptr<bzn::monitor_base> monitor,
+                std::shared_ptr<bzn::options_base> options);
 
         ~session();
 
@@ -94,6 +95,7 @@ namespace bzn
 
         std::shared_ptr<bzn::crypto_base> crypto;
         std::shared_ptr<bzn::monitor_base> monitor;
+        std::shared_ptr<bzn::options_base> options;
     };
 
 } // blz

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -66,6 +66,7 @@ namespace bzn
         // fwd declare test as it's not in the same namespace...
         class pbft_test_database_response_is_forwarded_to_session_Test;
         class pbft_test_add_session_to_sessions_waiting_can_add_a_session_and_shutdown_handler_removes_session_from_sessions_waiting_Test;
+        class pbft_test_pbft_wrap_message_sets_swarm_id_Test;
     }
 
     using request_hash_t = std::string;
@@ -324,6 +325,7 @@ namespace bzn
         FRIEND_TEST(pbft_newview_test, test_last_sequence_in_newview_prepared_proofs);
         FRIEND_TEST(bzn::test::pbft_test, database_response_is_forwarded_to_session);
         FRIEND_TEST(bzn::test::pbft_test, add_session_to_sessions_waiting_can_add_a_session_and_shutdown_handler_removes_session_from_sessions_waiting);
+        FRIEND_TEST(bzn::test::pbft_test, pbft_wrap_message_sets_swarm_id);
 
         friend class pbft_proto_test;
         friend class pbft_join_leave_test;

--- a/pbft/test/pbft_proto_test.cpp
+++ b/pbft/test/pbft_proto_test.cpp
@@ -250,7 +250,6 @@ namespace bzn
         force_checkpoint(10);
     }
 
-
     TEST_F(pbft_proto_test, test_backup_full_checkpoint)
     {
         this->uuid = SECOND_NODE_UUID;

--- a/pbft/test/pbft_test.cpp
+++ b/pbft/test/pbft_test.cpp
@@ -225,7 +225,6 @@ namespace bzn::test
         EXPECT_EQ(size_t(0), this->pbft->sessions_waiting_on_forwarded_requests.size());
     }
 
-
     TEST_F(pbft_test, client_request_executed_results_in_message_response)
     {
         auto mock_session = std::make_shared<bzn::Mocksession_base>();

--- a/proto/bluzelle.proto
+++ b/proto/bluzelle.proto
@@ -16,9 +16,10 @@ syntax = "proto3";
 
 message bzn_envelope
 {
-    string sender = 1;
-    bytes signature = 2;
-    uint64 timestamp = 3;
+    string swarm_id = 1;
+    string sender = 2;
+    bytes signature = 3;
+    uint64 timestamp = 4;
 
     oneof payload
     {


### PR DESCRIPTION
Added swarm id to the bzn_envelope protobuf structure and propagated the changes through the code. The swarm id parameter is set in pbft::wrap_message method. 