### PR TITLE
KEP-1605 - reduce impact of log messages

### DIFF
--- a/monitor/monitor.cpp
+++ b/monitor/monitor.cpp
@@ -144,7 +144,7 @@ monitor::format_counter(bzn::statistic stat, uint64_t amount)
 void
 monitor::send(const std::string& stat)
 {
-    LOG(debug) << "..." << (stat.length() <= 30 ? stat : stat.substr(stat.length() - 30));
+    LOG(trace) << "..." << (stat.length() <= 30 ? stat : stat.substr(stat.length() - 30));
     std::shared_ptr<boost::asio::const_buffer> buffer = std::make_shared<boost::asio::const_buffer>(stat.c_str(), stat.size());
     this->socket->async_send_to(*buffer, *(this->monitor_endpoint),
             [buffer](const boost::system::error_code& ec, std::size_t /*bytes*/)
@@ -162,7 +162,7 @@ monitor::maybe_send()
     auto threshold = this->time_last_sent + this->options->get_simple_options().get<uint64_t>(option_names::MONITOR_COLLATE_INTERVAL_SECONDS)*1000000;
     if (this->clock->microseconds_since_epoch() >= threshold)
     {
-        LOG(debug) << "Sending batched statistics:";
+        LOG(trace) << "Sending batched statistics:";
         for (const auto& pair : this->accumulated_stats)
         {
             this->send(this->format_counter(pair.first, pair.second));

--- a/pbft/operations/pbft_persistent_operation.cpp
+++ b/pbft/operations/pbft_persistent_operation.cpp
@@ -84,10 +84,10 @@ pbft_persistent_operation::pbft_persistent_operation(uint64_t view, uint64_t seq
     switch (response)
     {
         case storage_result::ok:
-            LOG(info) << "created persistent operation with prefix " << bzn::bytes_to_debug_string(this->prefix) << "; this is our first record of it";
+            LOG(trace) << "created persistent operation with prefix " << bzn::bytes_to_debug_string(this->prefix) << "; this is our first record of it";
             break;
         case storage_result::exists:
-            LOG(info) << "created persistent operation with prefix " << bzn::bytes_to_debug_string(this->prefix) << "; using existing records";
+            LOG(trace) << "created persistent operation with prefix " << bzn::bytes_to_debug_string(this->prefix) << "; using existing records";
             break;
         default:
             throw std::runtime_error("failed to write stage of new persistent operation " + storage_result_msg.at(response));
@@ -102,7 +102,7 @@ pbft_persistent_operation::pbft_persistent_operation(std::shared_ptr<bzn::storag
     , prefix(pbft_persistent_operation::generate_prefix(view, sequence, request_hash))
 {
     assert(this->storage->read(get_uuid(), generate_key(this->prefix, STAGE_KEY)));
-    LOG(info) << "re-hydrated operation with prefix " << bzn::bytes_to_debug_string(this->prefix);
+    LOG(trace) << "re-hydrated operation with prefix " << bzn::bytes_to_debug_string(this->prefix);
 }
 
 void
@@ -202,7 +202,7 @@ pbft_persistent_operation::record_request(const bzn_envelope& encoded_request)
 {
     if (this->transient_request_available)
     {
-        LOG(debug) << "ignoring record of request for operation " << bzn::bytes_to_debug_string(this->prefix) << " because we already have one";
+        LOG(trace) << "ignoring record of request for operation " << bzn::bytes_to_debug_string(this->prefix) << " because we already have one";
         return;
     }
 
@@ -211,10 +211,10 @@ pbft_persistent_operation::record_request(const bzn_envelope& encoded_request)
     switch (response)
     {
         case storage_result::ok:
-            LOG(debug) << "recorded request for operation " << bzn::bytes_to_debug_string(this->prefix);
+            LOG(trace) << "recorded request for operation " << bzn::bytes_to_debug_string(this->prefix);
             break;
         case storage_result::exists:
-            LOG(debug) << "ignoring record of request for operation " << bzn::bytes_to_debug_string(this->prefix) << " because we already have one";
+            LOG(trace) << "ignoring record of request for operation " << bzn::bytes_to_debug_string(this->prefix) << " because we already have one";
             break;
         case storage_result::value_too_large:
             LOG(debug) << "request too large to store: " << encoded_request.SerializeAsString().size() << " bytes, " << bzn::bytes_to_debug_string(this->prefix);

--- a/pbft/pbft.cpp
+++ b/pbft/pbft.cpp
@@ -222,7 +222,7 @@ pbft::handle_membership_message(const bzn_envelope& msg, std::shared_ptr<bzn::se
 void
 pbft::handle_message(const pbft_msg& msg, const bzn_envelope& original_msg)
 {
-    LOG(debug) << "Received message: " << msg.ShortDebugString().substr(0, MAX_MESSAGE_SIZE);
+    LOG(trace) << "Received message: " << msg.ShortDebugString().substr(0, MAX_MESSAGE_SIZE);
 
     std::lock_guard<std::mutex> lock(this->pbft_lock);
 
@@ -362,7 +362,7 @@ pbft::handle_request(const bzn_envelope& request_env, const std::shared_ptr<sess
     if (this->already_seen_request(request_env, hash))
     {
         // TODO: send error message to client
-        LOG(info) << "Rejecting duplicate request: " << request_env.ShortDebugString().substr(0, MAX_MESSAGE_SIZE);
+        LOG(trace) << "Rejecting duplicate request: " << request_env.ShortDebugString().substr(0, MAX_MESSAGE_SIZE);
         return;
     }
     this->saw_request(request_env, hash);
@@ -388,7 +388,7 @@ pbft::maybe_record_request(const bzn_envelope &request_env, const std::shared_pt
 {
     if (request_env.payload_case() == bzn_envelope::PayloadCase::PAYLOAD_NOT_SET || this->crypto->hash(request_env) != op->get_request_hash())
     {
-        LOG(info) << "Not recording request because hashes do not match";
+        LOG(trace) << "Not recording request because hashes do not match";
         return;
     }
     op->record_request(request_env);


### PR DESCRIPTION
Set some less than useful and verbose messages to "trace" level. Right now we don't have a way to enable trace messages but that could be added later.