### PR TITLE
KEP-1702 - various PBFT stability fixes

### DIFF
--- a/mocks/mock_options_base.hpp
+++ b/mocks/mock_options_base.hpp
@@ -48,6 +48,10 @@ class mock_options_base : public options_base {
         bzn::swarm_id_t());
   MOCK_CONST_METHOD0(get_ws_idle_timeout,
       std::chrono::milliseconds());
+    MOCK_CONST_METHOD0(get_fd_oper_timeout,
+        std::chrono::milliseconds());
+    MOCK_CONST_METHOD0(get_fd_fail_timeout,
+        std::chrono::milliseconds());
   MOCK_CONST_METHOD0(get_audit_mem_size,
       size_t());
   MOCK_CONST_METHOD0(get_state_dir,

--- a/node/node.cpp
+++ b/node/node.cpp
@@ -142,12 +142,6 @@ node::priv_protobuf_handler(const bzn_envelope& msg, std::shared_ptr<bzn::sessio
         return;
     }
 
-    if ((!msg.sender().empty()) && (!this->crypto->verify(msg)))
-    {
-        LOG(error) << "Dropping message with invalid signature: " << msg.ShortDebugString().substr(0, MAX_MESSAGE_SIZE);
-        return;
-    }
-
     if (auto it = this->protobuf_map.find(msg.payload_case()); it != this->protobuf_map.end())
     {
         it->second(msg, std::move(session));

--- a/node/test/node_test.cpp
+++ b/node/test/node_test.cpp
@@ -177,6 +177,7 @@ namespace  bzn
         ASSERT_FALSE(node->register_for_message(bzn_envelope::kDatabaseMsg, [](const auto&, auto){}));
     }
 
+#if 0
     TEST(node, test_that_wrongly_signed_messages_are_dropped)
     {
         auto mock_chaos = std::make_shared<NiceMock<bzn::mock_chaos_base>>();
@@ -211,4 +212,5 @@ namespace  bzn
         node->priv_protobuf_handler(anon_msg, mock_session);
         EXPECT_EQ(callback_execute, 1u);
     }
+#endif
 } // namespace bzn

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -141,6 +141,22 @@ options::get_ws_idle_timeout() const
     return std::chrono::milliseconds(raw_opts.get<uint64_t>(WS_IDLE_TIMEOUT));
 }
 
+std::chrono::milliseconds
+options::get_fd_oper_timeout() const
+{
+    //TODO: Remove this?
+    return std::chrono::milliseconds(raw_opts.get<uint64_t>(FD_OPER_TIMEOUT));
+}
+
+
+std::chrono::milliseconds
+options::get_fd_fail_timeout() const
+{
+    //TODO: Remove this?
+    return std::chrono::milliseconds(raw_opts.get<uint64_t>(FD_FAIL_TIMEOUT));
+}
+
+
 
 size_t
 options::get_audit_mem_size() const

--- a/options/options.hpp
+++ b/options/options.hpp
@@ -47,6 +47,10 @@ namespace bzn
 
         std::chrono::milliseconds get_ws_idle_timeout() const override;
 
+        std::chrono::milliseconds get_fd_oper_timeout() const override;
+
+        std::chrono::milliseconds get_fd_fail_timeout() const override;
+
         size_t get_audit_mem_size() const override;
 
         std::string get_state_dir() const override;

--- a/options/options_base.hpp
+++ b/options/options_base.hpp
@@ -119,6 +119,20 @@ namespace bzn
 
 
         /**
+         * Get the websocket activity timeout
+         * @return seconds
+         */
+        virtual std::chrono::milliseconds get_fd_oper_timeout() const = 0;
+
+
+        /**
+         * Get the websocket activity timeout
+         * @return seconds
+         */
+        virtual std::chrono::milliseconds get_fd_fail_timeout() const = 0;
+
+
+        /**
          * Get the number of entries allowed to be stored in audit's datastructures
          * @return size
          */

--- a/options/simple_options.cpp
+++ b/options/simple_options.cpp
@@ -88,6 +88,12 @@ simple_options::build_options()
                 (WS_IDLE_TIMEOUT.c_str(),
                         po::value<uint64_t>()->default_value(300000),
                         "websocket idle timeout (ms)")
+                (FD_OPER_TIMEOUT.c_str(),
+                        po::value<uint64_t>()->default_value(30000),
+                        "failure-detector operation timeout (ms)")
+                (FD_FAIL_TIMEOUT.c_str(),
+                        po::value<uint64_t>()->default_value(300000),
+                        "failure-detector second failure timeout (ms)")
                 (SWARM_INFO_ESR_ADDRESS.c_str(),
                         po::value<std::string>()->default_value(bzn::utils::DEFAULT_SWARM_INFO_ESR_ADDRESS),
                         "Address of ESR Swarm Info contract")

--- a/options/simple_options.hpp
+++ b/options/simple_options.hpp
@@ -45,6 +45,8 @@ namespace bzn::option_names
     const std::string STATE_DIR = "state_dir";
     const std::string SWARM_ID = "swarm_id";
     const std::string WS_IDLE_TIMEOUT = "ws_idle_timeout";
+    const std::string FD_OPER_TIMEOUT = "fd_oper_timeout";
+    const std::string FD_FAIL_TIMEOUT = "fd_fail_timeout";
     const std::string PEER_VALIDATION_ENABLED = "peer_validation_enabled";
     const std::string SIGNED_KEY = "signed_key";
     const std::string OWNER_PUBLIC_KEY = "owner_public_key";

--- a/pbft/pbft.hpp
+++ b/pbft/pbft.hpp
@@ -41,8 +41,8 @@ namespace
     const std::chrono::seconds NEW_CONFIG_INTERVAL{std::chrono::seconds(30)};
     const std::chrono::seconds JOIN_RETRY_INTERVAL{std::chrono::seconds(30)};
     const uint64_t CHECKPOINT_INTERVAL = 100; //TODO: KEP-574
-    const double HIGH_WATER_INTERVAL_IN_CHECKPOINTS = 2.0; //TODO: KEP-574
-    const uint64_t MAX_REQUEST_AGE_MS = 300000; // 5 minutes
+    const double HIGH_WATER_INTERVAL_IN_CHECKPOINTS = 200.0; //TODO: KEP-574
+    const uint64_t MAX_REQUEST_AGE_MS = 3600000; // 1 hour
     const std::string NOOP_REQUEST_HASH = "<no op request hash>";
 
     const std::string VIEW_KEY{"view"};
@@ -226,7 +226,7 @@ namespace bzn
         void join_swarm();
 
         // VIEWCHANGE/NEWVIEW Helper methods
-        void initiate_viewchange();
+        void initiate_viewchange(std::optional<uint64_t> opt_view = std::nullopt);
         std::shared_ptr<bzn_envelope> make_viewchange(uint64_t new_view, uint64_t n, const std::unordered_map<bzn::uuid_t, std::string>& stable_checkpoint_proof, const std::map<uint64_t, std::shared_ptr<bzn::pbft_operation>>& prepared_operations);
         pbft_msg make_newview(uint64_t new_view_index,  const std::map<uuid_t,bzn_envelope>& viewchange_envelopes_from_senders, const std::map<uint64_t, bzn_envelope>& pre_prepare_messages) const;
         pbft_msg build_newview(uint64_t new_view, const std::map<uuid_t,bzn_envelope>& viewchange_envelopes_from_senders, bool attach_reqs = true) const;

--- a/pbft/pbft_checkpoint_manager.cpp
+++ b/pbft/pbft_checkpoint_manager.cpp
@@ -263,7 +263,8 @@ pbft_checkpoint_manager::send_delayed_state_request(const checkpoint_t& cp)
 
                 auto strong_this = weak_this.lock();
 
-                if (strong_this && strong_this->get_latest_stable_checkpoint() == cp)
+                // only request state if we are still behind the stable checkpoint
+                if (strong_this && strong_this->latest_local_checkpoint.value().first < cp.first)
                 {
                     std::lock_guard<std::mutex> lock(strong_this->lock);
                     strong_this->send_state_request();

--- a/pbft/pbft_failure_detector.cpp
+++ b/pbft/pbft_failure_detector.cpp
@@ -15,15 +15,12 @@
 #include <pbft/pbft_failure_detector.hpp>
 #include <utils/bytes_to_debug_string.hpp>
 
-namespace
-{
-    const std::chrono::milliseconds operation_timeout{std::chrono::milliseconds(10000)};
-}
-
 using namespace bzn;
 
-pbft_failure_detector::pbft_failure_detector(std::shared_ptr<bzn::asio::io_context_base> io_context)
+pbft_failure_detector::pbft_failure_detector(std::shared_ptr<bzn::asio::io_context_base> io_context
+    , std::shared_ptr<bzn::options_base> options)
         : io_context(std::move(io_context))
+        , options(options)
         , request_progress_timer(this->io_context->make_unique_steady_timer())
 {
 }
@@ -31,14 +28,21 @@ pbft_failure_detector::pbft_failure_detector(std::shared_ptr<bzn::asio::io_conte
 void
 pbft_failure_detector::start_timer()
 {
-    this->request_progress_timer->expires_from_now(operation_timeout);
+    this->request_progress_timer->expires_from_now(this->options->get_fd_oper_timeout());
     this->request_progress_timer->async_wait(std::bind(&pbft_failure_detector::handle_timeout, shared_from_this(), std::placeholders::_1));
 }
 
 void
-pbft_failure_detector::handle_timeout(boost::system::error_code /*ec*/)
+pbft_failure_detector::handle_timeout(boost::system::error_code ec)
 {
+    if (ec)
+    {
+        return;
+    }
+
     std::lock_guard<std::mutex> lock(this->lock);
+
+    assert(!this->ordered_requests.empty());
 
     if (this->completed_requests.count(this->ordered_requests.front())  == 0)
     {
@@ -47,7 +51,9 @@ pbft_failure_detector::handle_timeout(boost::system::error_code /*ec*/)
         this->ordered_requests.pop_front();
         if (this->ordered_requests.size() > 0)
         {
-            this->start_timer();
+            LOG(debug) << "handle_failure starting secondary failure timer";
+            this->request_progress_timer->expires_from_now(this->options->get_fd_fail_timeout());
+            this->request_progress_timer->async_wait(std::bind(&pbft_failure_detector::handle_timeout, shared_from_this(), std::placeholders::_1));
         }
 
         this->io_context->post(std::bind(this->failure_handler));
@@ -62,6 +68,7 @@ pbft_failure_detector::handle_timeout(boost::system::error_code /*ec*/)
 
     if (this->ordered_requests.size() > 0)
     {
+        LOG(debug) << "handle_timeout starting timer";
         this->start_timer();
     }
 }
@@ -79,6 +86,7 @@ pbft_failure_detector::request_seen(const bzn::hash_t& req_hash)
 
         if (this->ordered_requests.size() == 1)
         {
+            LOG(debug) << "request_seen starting timer";
             this->start_timer();
         }
     }
@@ -88,6 +96,10 @@ void
 pbft_failure_detector::request_executed(const bzn::hash_t& req_hash)
 {
     std::lock_guard<std::mutex> lock(this->lock);
+    if (this->outstanding_requests.count(req_hash))
+    {
+        LOG(debug) << "Failure detector executed request " << bzn::bytes_to_debug_string(req_hash) << '\n';
+    }
 
     this->outstanding_requests.erase(req_hash);
     this->add_completed_request_hash(req_hash);

--- a/pbft/pbft_failure_detector.hpp
+++ b/pbft/pbft_failure_detector.hpp
@@ -17,6 +17,7 @@
 #include <pbft/pbft_failure_detector_base.hpp>
 #include <include/boost_asio_beast.hpp>
 #include <pbft/operations/pbft_operation.hpp>
+#include <options/options_base.hpp>
 #include <unordered_set>
 #include <queue>
 #include <list>
@@ -30,7 +31,7 @@ namespace bzn
     class pbft_failure_detector : public std::enable_shared_from_this<pbft_failure_detector>, public bzn::pbft_failure_detector_base
     {
     public:
-        pbft_failure_detector(std::shared_ptr<bzn::asio::io_context_base>);
+        pbft_failure_detector(std::shared_ptr<bzn::asio::io_context_base>, std::shared_ptr<bzn::options_base> options);
 
         void request_seen(const bzn::hash_t& req_hash) override;
 
@@ -49,6 +50,7 @@ namespace bzn
         void add_completed_request_hash(const bzn::hash_t& request_hash);
 
         std::shared_ptr<bzn::asio::io_context_base> io_context;
+        std::shared_ptr<bzn::options_base> options;
 
         std::unique_ptr<bzn::asio::steady_timer_base> request_progress_timer;
 
@@ -60,6 +62,7 @@ namespace bzn
         std::function<void()> failure_handler;
 
         std::mutex lock;
+        bool in_recovery{false};
     };
 
 }

--- a/pbft/test/pbft_failure_detector_test.cpp
+++ b/pbft/test/pbft_failure_detector_test.cpp
@@ -16,6 +16,7 @@
 #include <pbft/pbft_failure_detector.hpp>
 #include <proto/bluzelle.pb.h>
 #include <mocks/mock_boost_asio_beast.hpp>
+#include <mocks/mock_options_base.hpp>
 
 using namespace ::testing;
 
@@ -31,6 +32,8 @@ namespace bzn
                 std::make_shared<NiceMock<bzn::asio::mock_io_context_base>>();
         std::unique_ptr<bzn::asio::mock_steady_timer_base> request_timer =
                 std::make_unique<NiceMock<bzn::asio::mock_steady_timer_base>>();
+        std::shared_ptr<bzn::mock_options_base> mock_options =
+            std::make_shared<NiceMock<bzn::mock_options_base>>();
 
         bzn::asio::wait_handler request_timer_callback;
 
@@ -45,7 +48,7 @@ namespace bzn
 
         void build_failure_detector()
         {
-            this->failure_detector = std::make_shared<bzn::pbft_failure_detector>(this->mock_io_context);
+            this->failure_detector = std::make_shared<bzn::pbft_failure_detector>(this->mock_io_context, this->mock_options);
             this->failure_detector
                 ->register_failure_handler(std::bind(&pbft_failure_detector_test::failure_detect_handler, this));
         }

--- a/pbft/test/pbft_test.cpp
+++ b/pbft/test/pbft_test.cpp
@@ -225,16 +225,6 @@ namespace bzn::test
         service.apply_operation(op);
     }
 
-    TEST_F(pbft_test, messages_after_high_water_mark_dropped)
-    {
-        this->build_pbft();
-        EXPECT_CALL(*mock_node, send_signed_message(A<const boost::asio::ip::tcp::endpoint&>(), ResultOf(is_prepare, Eq(true))))
-                .Times(Exactly(0));
-
-        this->preprepare_msg.set_sequence(pbft->get_high_water_mark() + 1);
-        pbft->handle_message(preprepare_msg, default_original_msg);
-    }
-
     TEST_F(pbft_test, messages_before_low_water_mark_dropped)
     {
         this->build_pbft();

--- a/swarm/main.cpp
+++ b/swarm/main.cpp
@@ -271,7 +271,7 @@ main(int argc, const char* argv[])
         auto node = std::make_shared<bzn::node>(io_context, websocket, chaos, boost::asio::ip::tcp::endpoint{options->get_listener()}, crypto, options, monitor);
         auto audit = std::make_shared<bzn::audit>(io_context, node, options->get_audit_mem_size(), monitor);
 
-        auto failure_detector = std::make_shared<bzn::pbft_failure_detector>(io_context);
+        auto failure_detector = std::make_shared<bzn::pbft_failure_detector>(io_context, options);
 
         // which type of storage?
         std::shared_ptr<bzn::storage_base> stable_storage;


### PR DESCRIPTION
A mixed bag of bug fixes and improvements to make a busy swarm more stable. More work is in progress. This is an interim commit.

VIEWCHANGE and NEWVIEW messages were being sent repeatedly for the same view number every time there was a failure detected. These messages are very expensive to generate and process. We should now only send once per view.

VIEWCHANGE messages were sometimes being sent for the wrong view number due to a bug in the logic which is now fixed.

Missing pre-prepare messages, which are filled in with a “null database message” were being signed by the nodes that generated them, causing signature mismatches leading to invalid NEWVIEWs, causing stalls. These messages are no longer signed.

Delayed state transfer when we determine we are behind a checkpoint was incorrectly sending state requests when it didn’t need to. This has been fixed.

The point at which incoming messages are verified has been moved to later in the message processing so that messages we end up dropping (duplicate requests, invalid view messages etc., are not verified as that is an expensive process and we were wasting a lot of CPU cycles.

The upper bound on incoming message ids that we will process has been removed. Alternatively it could be set to a much larger number but I’m not sure what would be safe. This was found to have a major impact on stability in parallel request cases as we were frequently exceeding the message window and dropping valid messages, leading to unexecuted requests and view change loops. This is one of the biggest fixes in terms of stability.

The window for acceptable timestamps on requests has been increased substantially. Previously we were frequently not processing requests and their retries quickly enough to stay within the window, causing unexecuted requests and viewchange loops.

The failure handler has been modified to:

have a longer delay before it initially triggers a failure

have a secondary delay value (larger) that it uses after an initial failure, to allow time for a viewchange to occur and not immediately trigger another failure.

allow both the initial timeout value and the secondary timeout value to be configurable.

If the local view is invalid, don’t record any requests forwarded to the primary with the failure detector. Previously we would record the request, reject all the prepare/commit messages because the view was invalid, and then trigger a failure because we didn’t execute the request.