### PR TITLE
KEP-477 Support for Secure Websockets (WSS)

### DIFF
--- a/mocks/mock_boost_asio_beast.hpp
+++ b/mocks/mock_boost_asio_beast.hpp
@@ -146,8 +146,6 @@ namespace bzn::beast {
 
     class mock_websocket_stream_base : public websocket_stream_base {
     public:
-        MOCK_METHOD0(get_websocket,
-            boost::beast::websocket::stream<boost::asio::ip::tcp::socket>&());
         MOCK_METHOD1(async_accept,
             void(bzn::asio::accept_handler handler));
         MOCK_METHOD2(async_read,
@@ -173,8 +171,10 @@ namespace bzn::beast {
 
     class mock_websocket_base : public websocket_base {
     public:
-        MOCK_METHOD1(make_unique_websocket_stream,
+        MOCK_METHOD1(make_websocket_stream,
             std::unique_ptr<bzn::beast::websocket_stream_base>(boost::asio::ip::tcp::socket& socket));
+        MOCK_METHOD2(make_websocket_secure_stream,
+            std::shared_ptr<bzn::beast::websocket_stream_base>(boost::asio::ip::tcp::socket& socket, boost::asio::ssl::context& ctx));
     };
 
 }  // namespace bzn::beast

--- a/mocks/mock_options_base.hpp
+++ b/mocks/mock_options_base.hpp
@@ -79,7 +79,15 @@ class mock_options_base : public options_base {
   MOCK_CONST_METHOD0(get_swarm_info_esr_url,
       std::string());
   MOCK_CONST_METHOD0(get_stack,
-        std::string());
+      std::string());
+  MOCK_CONST_METHOD0(get_wss_enabled,
+      bool());
+  MOCK_CONST_METHOD0(get_wss_server_certificate_file,
+      std::string());
+  MOCK_CONST_METHOD0(get_wss_server_private_key_file,
+      std::string());
+  MOCK_CONST_METHOD0(get_wss_server_dh_params_file,
+      std::string());
 };
 
 }  // namespace bzn

--- a/mocks/smart_mock_io.cpp
+++ b/mocks/smart_mock_io.cpp
@@ -102,7 +102,7 @@ bzn::asio::smart_mock_io::smart_mock_io()
                 return mock_acceptor;
             }));
 
-    EXPECT_CALL(*(this->websocket), make_unique_websocket_stream(_)).WillRepeatedly(Invoke(
+    EXPECT_CALL(*(this->websocket), make_websocket_stream(_)).WillRepeatedly(Invoke(
             [&](auto& socket)
             {
                 auto id = this->socket_id_map.at(socket.native_handle());

--- a/node/node.hpp
+++ b/node/node.hpp
@@ -60,6 +60,8 @@ namespace bzn
         void priv_protobuf_handler(const bzn_envelope& msg, std::shared_ptr<bzn::session_base> session);
         void priv_session_shutdown_handler(const ep_key_t& ep_key);
 
+        void initialize_ssl_contexts();
+
         std::shared_ptr<bzn::pbft_base> pbft;
 
         std::shared_ptr<bzn::session_base> find_session(const boost::asio::ip::tcp::endpoint& ep);
@@ -85,6 +87,10 @@ namespace bzn
         std::shared_ptr<bzn::crypto_base> crypto;
         std::shared_ptr<bzn::options_base> options;
         std::shared_ptr<bzn::monitor_base> monitor;
+
+        std::shared_ptr<boost::asio::ssl::context> server_ctx;
+        std::shared_ptr<boost::asio::ssl::context> client_ctx;
+
     };
 
 } // bzn

--- a/node/session.hpp
+++ b/node/session.hpp
@@ -45,7 +45,8 @@ namespace bzn
                 std::shared_ptr<bzn::crypto_base> crypto,
                 std::shared_ptr<bzn::monitor_base> monitor,
                 std::shared_ptr<bzn::options_base> options,
-                std::optional<std::shared_ptr<bzn::asio::strand_base>> strand
+                std::optional<std::shared_ptr<bzn::asio::strand_base>> strand,
+                std::optional<std::shared_ptr<boost::asio::ssl::context>> ctx_opt = std::nullopt
                 );
 
         ~session();
@@ -100,6 +101,8 @@ namespace bzn
         std::shared_ptr<bzn::options_base> options;
         
         std::shared_ptr<bzn::asio::strand_base> strand;
+
+        std::shared_ptr<boost::asio::ssl::context> ctx; // for wss
     };
 
 } // blz

--- a/node/test/node_test.cpp
+++ b/node/test/node_test.cpp
@@ -162,9 +162,10 @@ namespace  bzn
     {
         auto mock_chaos = std::make_shared<NiceMock<bzn::mock_chaos_base>>();
         auto mock_io_context = std::make_shared<NiceMock<bzn::asio::mock_io_context_base>>();
-        auto options = std::shared_ptr<bzn::options>();
+        auto options = std::make_shared<bzn::options>();
         auto crypto = std::shared_ptr<bzn::crypto>();
         auto monitor = std::make_shared<NiceMock<bzn::mock_monitor>>();
+
         auto node = std::make_shared<bzn::node>(mock_io_context, nullptr, mock_chaos, TEST_ENDPOINT, crypto, options, monitor);
 
         // test that nulls are rejected...

--- a/node/test/session_test.cpp
+++ b/node/test/session_test.cpp
@@ -155,7 +155,7 @@ namespace bzn
     {
         this->session->send_message(std::make_shared<std::string>("hihi"));
 
-        this->session->accept(this->mock_io->websocket->make_unique_websocket_stream(
+        this->session->accept(this->mock_io->websocket->make_websocket_stream(
                                 this->mock_io->make_unique_tcp_socket()->get_tcp_socket()));
         this->yield();
         this->mock_io->ws_accept_handlers.at(0)(boost::system::error_code{});
@@ -167,7 +167,7 @@ namespace bzn
 
     TEST_F(session_test2, idle_timeout_closes_session)
     {
-        this->session->accept(this->mock_io->websocket->make_unique_websocket_stream(
+        this->session->accept(this->mock_io->websocket->make_websocket_stream(
                                 this->mock_io->make_unique_tcp_socket()->get_tcp_socket()));
         this->yield();
         this->mock_io->ws_accept_handlers.at(0)(boost::system::error_code{});
@@ -200,11 +200,13 @@ namespace bzn
 
         std::vector<uint8_t> handler_counters { 0,0,0 };
         {
+            auto options = std::make_shared<bzn::options>();
+
             auto session = std::make_shared<bzn::session>(io2
                     , 0, TEST_ENDPOINT, this->mock_chaos, [](auto, auto){}, TEST_TIMEOUT
                     , std::list<bzn::session_shutdown_handler>{[&handler_counters]() {
                         ++handler_counters[0];
-                    }}, nullptr, this->monitor, nullptr, std::nullopt);
+                    }}, nullptr, this->monitor, options, std::nullopt);
 
             session->add_shutdown_handler([&handler_counters](){++handler_counters[1];});
             session->add_shutdown_handler([&handler_counters](){++handler_counters[2];});

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -269,3 +269,31 @@ options::get_stack() const
 {
     return this->raw_opts.get<std::string>(STACK);
 }
+
+
+bool
+options::get_wss_enabled() const
+{
+    return this->raw_opts.get<bool>(WSS_ENABLED);
+}
+
+
+std::string
+options::get_wss_server_certificate_file() const
+{
+    return this->raw_opts.get<std::string>(WSS_SERVER_CERTIFICATE_FILE);
+}
+
+
+std::string
+options::get_wss_server_private_key_file() const
+{
+    return this->raw_opts.get<std::string>(WSS_SERVER_PRIVATE_KEY_FILE);
+}
+
+
+std::string
+options::get_wss_server_dh_params_file() const
+{
+    return this->raw_opts.get<std::string>(WSS_SERVER_DH_PARAMS_FILE);
+}

--- a/options/options.hpp
+++ b/options/options.hpp
@@ -77,6 +77,15 @@ namespace bzn
 
         std::string get_stack() const override;
 
+        bool get_wss_enabled() const override;
+
+        std::string get_wss_server_certificate_file() const override;
+
+        std::string get_wss_server_private_key_file() const override;
+
+        std::string get_wss_server_dh_params_file() const override;
+
+
     private:
         size_t parse_size(const std::string& key) const;
 

--- a/options/options_base.hpp
+++ b/options/options_base.hpp
@@ -215,10 +215,43 @@ namespace bzn
          */
         virtual std::string get_swarm_info_esr_url() const = 0;
 
+
         /**
          * Retrieve the name of the stack the swarm is using
          * @return string stack name
          */
         virtual std::string get_stack() const = 0;
+
+
+        /**
+         * Retrieve if we should be using tls or not
+         * @return true if ssl should be used
+         */
+        virtual bool get_wss_enabled() const = 0;
+
+
+        /**
+         *
+         * @return certificate file
+         */
+        virtual std::string get_wss_server_certificate_file() const = 0;
+
+
+        /**
+         *
+         * @return private key file
+         */
+        virtual std::string get_wss_server_private_key_file() const = 0;
+
+
+        /**
+         *
+         * @return dh params file
+         */
+        virtual std::string get_wss_server_dh_params_file() const = 0;
+
+
+        // todo: enable/disable peer validation
+
     };
 } // bzn

--- a/options/simple_options.cpp
+++ b/options/simple_options.cpp
@@ -180,8 +180,24 @@ simple_options::build_options()
                          po::value<bool>()->default_value(true),
                         "verify own signatures as a sanity check");
 
-
     this->options_root.add(crypto);
+
+    po::options_description wss("Websocket Secure");
+    wss.add_options()
+                (WSS_ENABLED.c_str(),
+                    po::value<bool>()->default_value(false),
+                    "enable websocket secure")
+                (WSS_SERVER_CERTIFICATE_FILE.c_str(),
+                    po::value<std::string>()->default_value(".state/wss-cert.pem"),
+                    "wss server certificate")
+                (WSS_SERVER_PRIVATE_KEY_FILE.c_str(),
+                    po::value<std::string>()->default_value(".state/wss-private-key.pem"),
+                    "wss server private key")
+                (WSS_SERVER_DH_PARAMS_FILE.c_str(),
+                    po::value<std::string>(),
+                    "Diffie–Hellman params");
+
+    this->options_root.add(wss);
 
     po::options_description chaos("Chaos testing");
     chaos.add_options()

--- a/options/simple_options.hpp
+++ b/options/simple_options.hpp
@@ -69,6 +69,11 @@ namespace bzn::option_names
     const std::string SWARM_INFO_ESR_URL = "swarm_info_esr_url";
 
     const std::string STACK = "stack";
+
+    const std::string WSS_ENABLED = "wss_enabled";
+    const std::string WSS_SERVER_CERTIFICATE_FILE = "wss_server_certificate_file";
+    const std::string WSS_SERVER_PRIVATE_KEY_FILE = "wss_server_private_key_file";
+    const std::string WSS_SERVER_DH_PARAMS_FILE = "wss_server_dh_params_file";
 }
 
 namespace bzn

--- a/options/test/options_test.cpp
+++ b/options/test/options_test.cpp
@@ -47,7 +47,11 @@ namespace
         "  \"owner_public_key\" : \"MCwwDQYJKoZIhvcNAQEBBQADGwAwGAIRAKb7PX3Pr+LgaqIAyhcXgTMCAwEAAQ==\","
         "  \"mem_storage\" : false,"
         "  \"swarm_info_esr_address\" : \"this_would_be_a_good_ESR_address\","
-        "  \"swarm_info_esr_url\" : \"192.0.0.1:41000\"";
+        "  \"swarm_info_esr_url\" : \"192.0.0.1:41000\","
+        "  \"wss_enabled\" : false,"
+        "  \"wss_server_certificate_file\" : \"cert.pem\","
+        "  \"wss_server_private_key_file\" : \"key.pem\","
+        "  \"wss_server_dh_params_file\" : \"dhparams.pem\"";
 
     const std::string DEFAULT_CONFIG_DATA = "{" + DEFAULT_CONFIG_CONTENT + "}";
 
@@ -157,6 +161,10 @@ TEST_F(options_file_test, test_that_loading_of_default_config_file)
     EXPECT_EQ("MCwwDQYJKoZIhvcNAQEBBQADGwAwGAIRAKb7PX3Pr+LgaqIAyhcXgTMCAwEAAQ==", options.get_owner_public_key());
     EXPECT_EQ("this_would_be_a_good_ESR_address", options.get_swarm_info_esr_address());
     EXPECT_EQ("192.0.0.1:41000", options.get_swarm_info_esr_url());
+    EXPECT_EQ(false, options.get_wss_enabled());
+    EXPECT_EQ("cert.pem", options.get_wss_server_certificate_file());
+    EXPECT_EQ("key.pem", options.get_wss_server_private_key_file());
+    EXPECT_EQ("dhparams.pem", options.get_wss_server_dh_params_file());
 
     // defaults..
     {
@@ -174,6 +182,10 @@ TEST_F(options_file_test, test_that_loading_of_default_config_file)
         EXPECT_EQ("", options0.get_swarm_id());
         EXPECT_EQ(bzn::utils::DEFAULT_SWARM_INFO_ESR_ADDRESS, options0.get_swarm_info_esr_address());
         EXPECT_EQ(bzn::utils::ROPSTEN_URL, options0.get_swarm_info_esr_url());
+        EXPECT_EQ(false, options0.get_wss_enabled());
+        EXPECT_EQ(".state/wss-cert.pem", options0.get_wss_server_certificate_file());
+        EXPECT_EQ(".state/wss-private-key.pem", options0.get_wss_server_private_key_file());
+        EXPECT_EQ("", options0.get_wss_server_dh_params_file());
     }
 }
 


### PR DESCRIPTION
Since this slides right into the mockable websocket there's no easy way to test the ssl part. An integration test may be the only real way. Unless you have some ideas in nodetest?

There is no peer validation until we figure out what to do there. So, self signed certs do not cause connection failures between nodes in a swarm.